### PR TITLE
PXD-2218 Feat/new upload flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _test.go
 *.test
 *.prof
 credentials.json
+
+# Mac
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ credentials.json
 
 # Mac
 .DS_Store
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN go get github.com/mitchellh/go-homedir \
     github.com/spf13/cobra \
     github.com/spf13/viper \
     github.com/cavaliercoder/grab \
-    github.com/golang/mock/gomock
+    github.com/golang/mock/gomock \
+    gopkg.in/cheggaaa/pb.v1
 
 COPY . .
 

--- a/gen3-client/g3cmd/configure.go
+++ b/gen3-client/g3cmd/configure.go
@@ -16,7 +16,7 @@ func init() {
 	Prompts for access_key, secret_key, and gdcapi endpoint
 	If a field is left empty, the existing value (if it exists) will remain unchanged
 	If no profile is specified, "default" profile is used`,
-		Example: `./gen3-client configure --profile=user1 --creds creds.json`,
+		Example: `./gen3-client configure --profile=user1 --cred cred.json`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			cred := conf.ReadCredentials(credFile)

--- a/gen3-client/g3cmd/download-manifest.go
+++ b/gen3-client/g3cmd/download-manifest.go
@@ -109,7 +109,7 @@ func init() {
 				reqs := make([]*grab.Request, 0)
 				for _, object := range objects {
 					endPointPostfix := "/user/data/download/" + object.ObjectID + protocolText
-					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, nil)
 
 					if err != nil {
 						if strings.Contains(err.Error(), "The provided guid") {
@@ -131,7 +131,7 @@ func init() {
 			} else {
 				for _, object := range objects {
 					endPointPostfix := "/user/data/download/" + object.ObjectID + protocolText
-					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, nil)
 
 					if err != nil {
 						if strings.Contains(err.Error(), "The provided guid") {

--- a/gen3-client/g3cmd/download-manifest.go
+++ b/gen3-client/g3cmd/download-manifest.go
@@ -15,11 +15,6 @@ import (
 	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
 )
 
-type ManifestObject struct {
-	ObjectID  string `json:"object_id"`
-	SubjectID string `json:"subject_id"`
-}
-
 func batchDownload(numParallel int, reqs []*grab.Request) {
 
 	client := grab.NewClient()

--- a/gen3-client/g3cmd/download-manifest.go
+++ b/gen3-client/g3cmd/download-manifest.go
@@ -109,7 +109,7 @@ func init() {
 				reqs := make([]*grab.Request, 0)
 				for _, object := range objects {
 					endPointPostfix := "/user/data/download/" + object.ObjectID + protocolText
-					respURL, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
 
 					if err != nil {
 						if strings.Contains(err.Error(), "The provided guid") {
@@ -131,7 +131,7 @@ func init() {
 			} else {
 				for _, object := range objects {
 					endPointPostfix := "/user/data/download/" + object.ObjectID + protocolText
-					respURL, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
 
 					if err != nil {
 						if strings.Contains(err.Error(), "The provided guid") {

--- a/gen3-client/g3cmd/download.go
+++ b/gen3-client/g3cmd/download.go
@@ -102,7 +102,7 @@ func init() {
 	downloadCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
 	downloadCmd.MarkFlagRequired("guid")
 	downloadCmd.Flags().StringVar(&filePath, "file", "", "Specify file to download to with --file=~/path/to/file")
-	downloadCmd.MarkFlagRequired("file")
+	// downloadCmd.MarkFlagRequired("file")
 	downloadCmd.Flags().StringVar(&protocol, "protocol", "", "Specify the preferred protocol with --protocol=gs")
 	RootCmd.AddCommand(downloadCmd)
 }

--- a/gen3-client/g3cmd/download.go
+++ b/gen3-client/g3cmd/download.go
@@ -84,7 +84,7 @@ func init() {
 
 			endPointPostfix := "/user/data/download/" + guid + protocolText
 
-			respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+			respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, nil)
 
 			if err != nil {
 				if strings.Contains(err.Error(), "The provided guid") {

--- a/gen3-client/g3cmd/download.go
+++ b/gen3-client/g3cmd/download.go
@@ -63,11 +63,10 @@ func init() {
 	var protocol string
 
 	var downloadCmd = &cobra.Command{
-		Use:   "download",
-		Short: "download a file from a UUID",
-		Long: `Gets a presigned URL for a file from a GUID and then downloads the specified file.
-	Examples: ./gen3-client download --profile user1 --guid 206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc --file=~/Documents/file_to_download.json 
-	`,
+		Use:     "download",
+		Short:   "download a file from a GUID",
+		Long:    `Gets a presigned URL for a file from a GUID and then downloads the specified file.`,
+		Example: `./gen3-client download --profile user1 --guid 206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc --file=~/Documents/file_to_download.json`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			request := new(jwt.Request)

--- a/gen3-client/g3cmd/download.go
+++ b/gen3-client/g3cmd/download.go
@@ -84,7 +84,7 @@ func init() {
 
 			endPointPostfix := "/user/data/download/" + guid + protocolText
 
-			respURL, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+			respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
 
 			if err != nil {
 				if strings.Contains(err.Error(), "The provided guid") {

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -15,10 +15,10 @@ var uri string
 
 /* RootCmd represents the base command when called without any subcommands */
 var RootCmd = &cobra.Command{
-	Use:   "gen3-client",
-	Short: "Use the gen3-client to interact with a Gen3 Data Commons",
-	// Long:    "Gen3 Client for downloading, uploading and submitting data to data commons.\ngen3-client version: " + gitversion + ", commit: " + gitcommit,
-	// Version: gitversion,
+	Use:     "gen3-client",
+	Short:   "Use the gen3-client to interact with a Gen3 Data Commons",
+	Long:    "Gen3 Client for downloading, uploading and submitting data to data commons.\ngen3-client version: " + gitversion + ", commit: " + gitcommit,
+	Version: gitversion,
 }
 
 /* Execute adds all child commands to the root command sets flags appropriately

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -15,10 +15,10 @@ var uri string
 
 /* RootCmd represents the base command when called without any subcommands */
 var RootCmd = &cobra.Command{
-	Use:     "gen3-client",
-	Short:   "Use the gen3-client to interact with a Gen3 Data Commons",
-	Long:    "Gen3 Client for downloading, uploading and submitting data to data commons.\ngen3-client version: " + gitversion + ", commit: " + gitcommit,
-	Version: gitversion,
+	Use:   "gen3-client",
+	Short: "Use the gen3-client to interact with a Gen3 Data Commons",
+	// Long:    "Gen3 Client for downloading, uploading and submitting data to data commons.\ngen3-client version: " + gitversion + ", commit: " + gitcommit,
+	// Version: gitversion,
 }
 
 /* Execute adds all child commands to the root command sets flags appropriately

--- a/gen3-client/g3cmd/upload-manifest.go
+++ b/gen3-client/g3cmd/upload-manifest.go
@@ -1,0 +1,209 @@
+package g3cmd
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
+)
+
+// doBatchHTTPClient executes a batch of HTTP PUT requests using worker pool. The default number of workers is 3
+func doBatchHTTPClient(client *http.Client, workers int, requests ...*http.Request) (<-chan *http.Response, <-chan error) {
+	if workers < 1 || workers > len(requests) {
+		workers = len(requests)
+	}
+
+	// channels for requests, responses and errors
+	reqch := make(chan *http.Request, len(requests))
+	respch := make(chan *http.Response, len(requests))
+	errch := make(chan error, len(requests))
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			for req := range reqch {
+				resp, err := client.Do(req)
+				if err != nil {
+					errch <- err
+				} else {
+					respch <- resp
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	for _, req := range requests {
+		reqch <- req
+	}
+	close(reqch)
+
+	wg.Wait()
+	close(respch)
+	return respch, errch
+}
+
+func batchUpload(numParallel int, reqs []*http.Request) {
+	client := &http.Client{}
+	respch, errch := doBatchHTTPClient(client, numParallel, reqs...)
+
+	t := time.NewTicker(200 * time.Millisecond)
+
+	completed := 0
+	responses := make([]*http.Response, 0)
+	errors := make([]error, 0)
+	for completed < len(reqs) {
+		select {
+		case resp := <-respch:
+			if resp != nil {
+				responses = append(responses, resp)
+			}
+		case err := <-errch:
+			if err != nil {
+				errors = append(errors, err)
+			}
+
+		case <-t.C:
+			for i, resp := range responses {
+				if resp != nil {
+					if resp.StatusCode == http.StatusOK {
+						fmt.Printf("Finished\n")
+					} else {
+						fmt.Printf("%d %s %d\n", resp.StatusCode, resp.Status, i)
+					}
+					responses[i] = nil
+					completed++
+				}
+			}
+
+			for i, err := range errors {
+				if err != nil {
+					fmt.Printf("Error\n")
+					errors[i] = nil
+					completed++
+				}
+			}
+		}
+	}
+
+	t.Stop()
+	fmt.Printf("%d files uploaded.\n", len(reqs))
+}
+
+func init() {
+	var manifestPath string
+	var uploadPath string
+	var fileType string
+	var batch bool
+	var numParallel int
+
+	var uploadManifestCmd = &cobra.Command{
+		Use:   "upload-manifest",
+		Short: "upload files from a specified manifest",
+		Long: `Gets a presigned URL for a file from a GUID and then uploads the specified file.
+	Examples: ./gen3-client upload-manifest --profile user1 --manifest manifest.tsv --upload-path=files/ 
+	`,
+		Run: func(cmd *cobra.Command, args []string) {
+
+			request := new(jwt.Request)
+			configure := new(jwt.Configure)
+			function := new(jwt.Functions)
+
+			function.Config = configure
+			function.Request = request
+
+			var objects []ManifestObject
+
+			manifestFile, err := os.Open(manifestPath)
+			if err != nil {
+				panic(err)
+			}
+			defer manifestFile.Close()
+
+			switch {
+			case strings.EqualFold(filepath.Ext(manifestPath), ".tsv"):
+				r := csv.NewReader(manifestFile)
+				r.Comma = '\t'
+				for {
+					record, err := r.Read()
+					if err == io.EOF {
+						break
+					} else if err != nil {
+						log.Fatalf("TSV parse error\n")
+					}
+					objects = append(objects, ManifestObject{ObjectID: record[0], SubjectID: record[1]})
+				}
+			case strings.EqualFold(filepath.Ext(manifestPath), ".json"):
+				manifestBytes, err := ioutil.ReadFile(manifestPath)
+				if err != nil {
+					log.Fatalf("Failed reading manifest %s, %v\n", manifestPath, err)
+				}
+				json.Unmarshal(manifestBytes, &objects)
+			default:
+				log.Fatalf("Unsupported manifast format")
+				return
+			}
+
+			if batch {
+				reqs := make([]*http.Request, 0)
+				for _, object := range objects {
+					endPointPostfix := "/user/data/upload/" + object.ObjectID
+					respURL, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+
+					data, err := ioutil.ReadFile(uploadPath + "/" + object.SubjectID)
+					if err != nil {
+						fmt.Println(err.Error())
+						break
+					}
+					body := bytes.NewBufferString(string(data[:]))
+					contentType := "application/json"
+					if fileType == "tsv" {
+						contentType = "text/tab-separated-values"
+					}
+					req, _ := http.NewRequest(http.MethodPut, respURL, body)
+					req.Header.Set("content_type", contentType)
+					reqs = append(reqs, req)
+				}
+				batchUpload(numParallel, reqs)
+			} else {
+				for _, object := range objects {
+					endPointPostfix := "/user/data/upload/" + object.ObjectID
+					respURL, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+
+					if err != nil {
+						if strings.Contains(err.Error(), "The provided guid") {
+							log.Printf("Upload error: %s\n", err)
+						} else {
+							log.Fatalf("Fatal upload error: %s\n", err)
+						}
+					} else {
+						uploadFile(object.ObjectID, uploadPath+"/"+object.SubjectID, fileType, respURL)
+					}
+				}
+			}
+		},
+	}
+
+	uploadManifestCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from")
+	uploadManifestCmd.MarkFlagRequired("manifest")
+	uploadManifestCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory in which contains files to be uploaded")
+	uploadManifestCmd.MarkFlagRequired("upload-path")
+	uploadManifestCmd.Flags().StringVar(&fileType, "file-type", "json", "Specify file type you're uploading with --file-type={json|tsv} (defaults to json)")
+	uploadManifestCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")
+	uploadManifestCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
+	RootCmd.AddCommand(uploadManifestCmd)
+}

--- a/gen3-client/g3cmd/upload-manifest.go
+++ b/gen3-client/g3cmd/upload-manifest.go
@@ -185,7 +185,7 @@ func init() {
 				bars := make([]*pb.ProgressBar, 0)
 				for _, object := range objects {
 					endPointPostfix := "/user/data/upload/" + object.ObjectID
-					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, nil)
 
 					file, err := os.Open(uploadPath + "/" + object.SubjectID)
 					if err != nil {
@@ -207,7 +207,7 @@ func init() {
 			} else {
 				for _, object := range objects {
 					endPointPostfix := "/user/data/upload/" + object.ObjectID
-					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, nil)
 
 					if err != nil {
 						if strings.Contains(err.Error(), "The provided guid") {
@@ -230,6 +230,6 @@ func init() {
 	uploadManifestCmd.MarkFlagRequired("upload-path")
 	uploadManifestCmd.Flags().StringVar(&fileType, "file-type", "json", "Specify file type you're uploading with --file-type={json|tsv} (defaults to json)")
 	uploadManifestCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")
-	uploadManifestCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
+	uploadManifestCmd.Flags().IntVar(&numParallel, "numparallel", 2, "Number of uploads to run in parallel")
 	RootCmd.AddCommand(uploadManifestCmd)
 }

--- a/gen3-client/g3cmd/upload-new.go
+++ b/gen3-client/g3cmd/upload-new.go
@@ -2,6 +2,7 @@ package g3cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -9,17 +10,22 @@ import (
 	"os"
 	"path/filepath"
 
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	pb "gopkg.in/cheggaaa/pb.v1"
 
 	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
 )
+
+var historyFile string
+var historyFileMap map[string]interface{}
 
 func init() {
 	var uploadPath string
 	var fileType string
 	var batch bool
 	var numParallel int
-	var files []string
+	var filePaths []string
 
 	var uploadNewCmd = &cobra.Command{
 		Use:   "upload-new",
@@ -28,6 +34,7 @@ func init() {
 	Examples: ./gen3-client upload-new --profile user1 --upload-path=files/ 
 	`,
 		Run: func(cmd *cobra.Command, args []string) {
+			initHistory()
 
 			request := new(jwt.Request)
 			configure := new(jwt.Configure)
@@ -46,54 +53,106 @@ func init() {
 					log.Fatal(err)
 				}
 				for _, file := range dirFiles {
-					files = append(files, filepath.Join(uploadPath, file.Name()))
+					filePaths = append(filePaths, filepath.Join(uploadPath, file.Name()))
 				}
 			} else {
-				files = append(files, uploadPath)
+				filePaths = append(filePaths, uploadPath)
 			}
 
-			if batch {
-				reqs := make([]*http.Request, 0)
-				for _, file := range files {
-					endPointPostfix := "/user/data/upload/" + filepath.Base(file)
-					respURL, UUID, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+			reqs := make([]*http.Request, 0)
+			bars := make([]*pb.ProgressBar, 0)
+			for _, filePath := range filePaths {
+				_, present := historyFileMap[filePath]
+				if present {
+					fmt.Printf("File %s has been found in local submission history and has be skipped for preventing duplicated submissions.\n", filePath)
+					continue
+				}
+				endPointPostfix := "/user/data/upload"
+				dataBody := bytes.NewBufferString("{\"filename\": \"" + filepath.Base(filePath) + "\"}")
+				respURL, GUID, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, dataBody)
 
-					data, err := ioutil.ReadFile(file)
+				if batch {
+					file, err := os.Open(filePath)
+					if err != nil {
+						log.Fatal("File Error")
+					}
+					defer file.Close()
+
+					req, bar, err := GenerateUploadRequest(file, fileType, respURL)
+
 					if err != nil {
 						fmt.Println(err.Error())
 						break
 					}
-					body := bytes.NewBufferString(string(data[:]))
-					contentType := "application/json"
-					if fileType == "tsv" {
-						contentType = "text/tab-separated-values"
-					}
-					req, _ := http.NewRequest(http.MethodPut, respURL, body)
-					req.Header.Set("content_type", contentType)
-					reqs = append(reqs, req)
-					//TODO: save uuid
-					fmt.Println(UUID)
-				}
-				batchUpload(numParallel, reqs, nil)
-			} else {
-				for _, file := range files {
-					endPointPostfix := "/user/data/upload/" + filepath.Base(file)
-					respURL, UUID, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
 
+					reqs = append(reqs, req)
+					bars = append(bars, bar)
+					fmt.Println(GUID)
+				} else {
 					if err != nil {
 						log.Fatalf("Fatal upload error: %s\n", err)
 					} else {
-						uploadFile("", uploadPath+"/"+UUID, fileType, respURL)
+						uploadFile(GUID, filePath, fileType, respURL)
 					}
 				}
+				historyFileMap[filePath] = GUID
 			}
+
+			if batch {
+				batchUpload(numParallel, reqs, nil)
+			}
+
+			jsonData, err := json.Marshal(historyFileMap)
+			if err != nil {
+				panic(err)
+			}
+			jsonFile, err := os.OpenFile(historyFile, os.O_RDWR|os.O_CREATE, 0666)
+			if err != nil {
+				panic(err)
+			}
+			defer jsonFile.Close()
+
+			jsonFile.Write(jsonData)
+			jsonFile.Close()
+			fmt.Println("Local history data updated in ", jsonFile.Name())
 		},
 	}
 
 	uploadNewCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory or file in which contains file(s) to be uploaded")
 	uploadNewCmd.MarkFlagRequired("upload-path")
 	uploadNewCmd.Flags().StringVar(&fileType, "file-type", "json", "Specify file type you're uploading with --file-type={json|tsv} (defaults to json)")
-	uploadNewCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")
+	uploadNewCmd.Flags().BoolVar(&batch, "batch", false, "Upload in parallel")
 	uploadNewCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
 	RootCmd.AddCommand(uploadNewCmd)
+}
+
+func initHistory() {
+	home, err := homedir.Dir()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	historyFile = home + "/.gen3/" + profile + "_history.json"
+	fmt.Println(historyFile)
+
+	file, _ := os.OpenFile(historyFile, os.O_RDWR|os.O_CREATE, 0666)
+	fi, err := file.Stat()
+	if err != nil {
+		panic(err)
+	}
+
+	if fi.Size() > 0 {
+		historyFileMap = make(map[string]interface{})
+
+		data, err := ioutil.ReadAll(file)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = json.Unmarshal(data, &historyFileMap)
+		if err != nil {
+			panic(err)
+		}
+	}
 }

--- a/gen3-client/g3cmd/upload-new.go
+++ b/gen3-client/g3cmd/upload-new.go
@@ -1,0 +1,99 @@
+package g3cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
+)
+
+func init() {
+	var uploadPath string
+	var fileType string
+	var batch bool
+	var numParallel int
+	var files []string
+
+	var uploadNewCmd = &cobra.Command{
+		Use:   "upload-new",
+		Short: "upload file(s) with a new flow.",
+		Long: `Gets a presigned URL for a file and then uploads the specified file.
+	Examples: ./gen3-client upload-new --profile user1 --upload-path=files/ 
+	`,
+		Run: func(cmd *cobra.Command, args []string) {
+
+			request := new(jwt.Request)
+			configure := new(jwt.Configure)
+			function := new(jwt.Functions)
+
+			function.Config = configure
+			function.Request = request
+
+			fi, err := os.Stat(uploadPath)
+			if err != nil {
+				panic(err)
+			}
+			if fi.IsDir() {
+				dirFiles, err := ioutil.ReadDir(uploadPath)
+				if err != nil {
+					log.Fatal(err)
+				}
+				for _, file := range dirFiles {
+					files = append(files, filepath.Join(uploadPath, file.Name()))
+				}
+			} else {
+				files = append(files, uploadPath)
+			}
+
+			if batch {
+				reqs := make([]*http.Request, 0)
+				for _, file := range files {
+					endPointPostfix := "/user/data/upload/" + filepath.Base(file)
+					respURL, UUID, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+
+					data, err := ioutil.ReadFile(file)
+					if err != nil {
+						fmt.Println(err.Error())
+						break
+					}
+					body := bytes.NewBufferString(string(data[:]))
+					contentType := "application/json"
+					if fileType == "tsv" {
+						contentType = "text/tab-separated-values"
+					}
+					req, _ := http.NewRequest(http.MethodPut, respURL, body)
+					req.Header.Set("content_type", contentType)
+					reqs = append(reqs, req)
+					//TODO: save uuid
+					fmt.Println(UUID)
+				}
+				batchUpload(numParallel, reqs, nil)
+			} else {
+				for _, file := range files {
+					endPointPostfix := "/user/data/upload/" + filepath.Base(file)
+					respURL, UUID, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+
+					if err != nil {
+						log.Fatalf("Fatal upload error: %s\n", err)
+					} else {
+						uploadFile("", uploadPath+"/"+UUID, fileType, respURL)
+					}
+				}
+			}
+		},
+	}
+
+	uploadNewCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory or file in which contains file(s) to be uploaded")
+	uploadNewCmd.MarkFlagRequired("upload-path")
+	uploadNewCmd.Flags().StringVar(&fileType, "file-type", "json", "Specify file type you're uploading with --file-type={json|tsv} (defaults to json)")
+	uploadNewCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")
+	uploadNewCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
+	RootCmd.AddCommand(uploadNewCmd)
+}

--- a/gen3-client/g3cmd/upload-new.go
+++ b/gen3-client/g3cmd/upload-new.go
@@ -17,7 +17,7 @@ import (
 )
 
 var historyFile string
-var historyFileMap map[string]interface{}
+var historyFileMap map[string]string
 
 func init() {
 	var uploadPath string
@@ -97,7 +97,7 @@ func init() {
 					uploadFile(req, bar, guid, filePath)
 					file.Close()
 				}
-				historyFileMap[filePath] = "guid"
+				historyFileMap[filePath] = guid
 			}
 
 			if batch {
@@ -116,7 +116,7 @@ func init() {
 
 			jsonFile.Write(jsonData)
 			jsonFile.Close()
-			fmt.Println("Local history data updated in %s", jsonFile.Name())
+			fmt.Println("Local history data updated in ", jsonFile.Name())
 		},
 	}
 
@@ -144,7 +144,7 @@ func initHistory() {
 		panic(err)
 	}
 
-	historyFileMap = make(map[string]interface{})
+	historyFileMap = make(map[string]string)
 	if fi.Size() > 0 {
 		data, err := ioutil.ReadAll(file)
 		if err != nil {

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -61,7 +61,7 @@ func init() {
 
 			endPointPostfix := "/user/data/upload/" + guid
 
-			signedURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix)
+			signedURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, nil)
 			if err != nil && !strings.Contains(err.Error(), "No UUID found") {
 				log.Fatalf("Upload error: %s!\n", err)
 			} else {

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -12,8 +12,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
+
+type ManifestObject struct {
+	ObjectID  string `json:"object_id"`
+	SubjectID string `json:"subject_id"`
+}
+
+type NewFlowRequestObject struct {
+	Filename string `json:"file_name"`
+}
 
 func parse_config(profile string) (string, string, string) {
 	//Look in config file
@@ -88,19 +98,31 @@ func parse_config(profile string) (string, string, string) {
 	}
 }
 
-func GenerateUploadRequest(file *os.File, fileType string, signedURL string) (*http.Request, *pb.ProgressBar, error) {
+func GenerateUploadRequest(guid string, url string, file *os.File, fileType string) (*http.Request, *pb.ProgressBar, error) {
+	request := new(jwt.Request)
+	configure := new(jwt.Configure)
+	function := new(jwt.Functions)
+
+	function.Config = configure
+	function.Request = request
+
+	if url == "" {
+		endPointPostfix := "/user/data/upload/" + guid
+		signedURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, nil)
+		if err != nil && !strings.Contains(err.Error(), "No GUID found") {
+			log.Fatalf("Upload error: %s!\n", err)
+			return nil, nil, err
+		}
+		url = signedURL
+	}
+
 	fi, err := file.Stat()
 	if err != nil {
 		log.Fatal("File Stat Error")
 	}
 
 	bar := pb.New(int(fi.Size())).SetUnits(pb.U_BYTES).SetRefreshRate(time.Millisecond).Prefix(fi.Name() + " ")
-	contentType := "application/json"
-	if fileType == "tsv" {
-		contentType = "text/tab-separated-values"
-	}
-	req, err := http.NewRequest(http.MethodPut, signedURL, bar.NewProxyReader(file))
-	req.Header.Set("content_type", contentType)
+	req, err := http.NewRequest(http.MethodPut, url, bar.NewProxyReader(file))
 	req.ContentLength = fi.Size()
 
 	return req, bar, err

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -5,7 +5,6 @@ package jwt
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -45,7 +44,6 @@ func (r *Request) MakeARequest(client *http.Client, method string, apiEndpoint s
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
-	fmt.Println(body)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -219,9 +217,6 @@ func (r *Request) GetPresignedURLPost(host *url.URL, endpointPostPrefix string, 
 	headers["Content-Type"] = "application/json"
 	headers["Authorization"] = "Bearer " + accessKey
 	client := &http.Client{}
-	fmt.Println(apiEndPoint)
-	fmt.Println(headers)
-	fmt.Println(body)
 	resp, err := r.MakeARequest(client, "POST", apiEndPoint, headers, body)
 	if err != nil {
 		panic(err)
@@ -252,7 +247,6 @@ func (r *Request) SignedRequest(method string, url_string string, body io.Reader
 		return nil, err
 	}
 	req.Header.Add("Authorization", "Bearer "+access_key)
-	fmt.Println(req.Header)
 
 	return client.Do(req)
 }

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -100,10 +100,6 @@ func (f *Functions) ParseFenceURLResponse(resp *http.Response) (JsonMessage, err
 		return msg, errors.New("The provided guid at url \"" + resp.Request.URL.String() + "\" is not found!")
 	}
 
-	if resp.StatusCode == 401 {
-		return msg, errors.New("You don't have premission to access url \"" + resp.Request.URL.String() + "\"!")
-	}
-
 	str := ResponseToString(resp)
 	if strings.Contains(str, "Can't find a location for the data") {
 		return msg, errors.New("The provided guid is not found!")

--- a/gen3-client/jwt/utils.go
+++ b/gen3-client/jwt/utils.go
@@ -16,7 +16,7 @@ type AccessTokenStruct struct {
 
 type JsonMessage struct {
 	Url  string
-	UUID string
+	GUID string
 }
 
 type DoRequest func(*http.Response) *http.Response

--- a/gen3-client/jwt/utils.go
+++ b/gen3-client/jwt/utils.go
@@ -15,7 +15,8 @@ type AccessTokenStruct struct {
 }
 
 type JsonMessage struct {
-	Url string
+	Url  string
+	UUID string
 }
 
 type DoRequest func(*http.Response) *http.Response

--- a/gen3-client/jwt/utils.go
+++ b/gen3-client/jwt/utils.go
@@ -29,8 +29,5 @@ func ResponseToString(resp *http.Response) string {
 
 func DecodeJsonFromString(str string, msg Message) error {
 	err := json.Unmarshal([]byte(str), &msg)
-	if err != nil {
-		panic(err)
-	}
 	return err
 }

--- a/gen3-client/mocks/mock_request.go
+++ b/gen3-client/mocks/mock_request.go
@@ -45,9 +45,19 @@ func (m *MockRequestInterface) GetPresignedURL(arg0 *url.URL, arg1, arg2 string)
 	return ret0
 }
 
+func (m *MockRequestInterface) GetPresignedURLPost(arg0 *url.URL, arg1, arg2 string, arg3 *bytes.Buffer) *http.Response {
+	ret := m.ctrl.Call(m, "GetPresignedURLPost", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*http.Response)
+	return ret0
+}
+
 // GetPresignedURL indicates an expected call of GetPresignedURL
 func (mr *MockRequestInterfaceMockRecorder) GetPresignedURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPresignedURL", reflect.TypeOf((*MockRequestInterface)(nil).GetPresignedURL), arg0, arg1, arg2)
+}
+
+func (mr *MockRequestInterfaceMockRecorder) GetPresignedURLPost(arg0, arg1, arg2, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPresignedURLPost", reflect.TypeOf((*MockRequestInterface)(nil).GetPresignedURLPost), arg0, arg1, arg2)
 }
 
 // MakeARequest mocks base method

--- a/tests/functions_test.go
+++ b/tests/functions_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -27,7 +28,7 @@ func TestDoRequestWithSignedHeaderNoProfile(t *testing.T) {
 
 	mockConfig.EXPECT().ParseConfig(gomock.Any()).Return(cred).Times(1)
 
-	_, err := testFunction.DoRequestWithSignedHeader("default", "not_json", "/user/data/download/test_uuid")
+	_, _, err := testFunction.DoRequestWithSignedHeader("default", "not_json", "/user/data/download/test_uuid", nil)
 
 	if err == nil {
 		t.Fail()
@@ -51,9 +52,9 @@ func TestDoRequestWithSignedHeaderGoodToken(t *testing.T) {
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
 	mockRequest.EXPECT().GetPresignedURL(gomock.Any(), "/user/data/download/test_uuid", "non_exprired_token").Return(mockedResp).Times(1)
 
-	_, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid")
+	_, _, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", nil)
 
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "No GUID found in ") {
 		t.Fail()
 	}
 }
@@ -76,15 +77,14 @@ func TestDoRequestWithSignedHeaderCreateNewToken(t *testing.T) {
 	mockConfig.EXPECT().ReadFile(gomock.Any(), gomock.Any()).Times(1)
 	mockConfig.EXPECT().UpdateConfigFile(cred, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
-	mockRequest.EXPECT().RequestNewAccessKey("http://www.test.com/user/credentials/cdis/access_token", &cred).Times(1)
+	mockRequest.EXPECT().RequestNewAccessKey("http://www.test.com/user/credentials/api/access_token", &cred).Times(1)
 	mockRequest.EXPECT().GetPresignedURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockedResp).Times(1)
 
-	_, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid")
+	_, _, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", nil)
 
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "No GUID found in ") {
 		t.Fail()
 	}
-
 }
 
 func TestDoRequestWithSignedHeaderRefreshToken(t *testing.T) {
@@ -106,12 +106,12 @@ func TestDoRequestWithSignedHeaderRefreshToken(t *testing.T) {
 	mockConfig.EXPECT().ReadFile(gomock.Any(), gomock.Any()).Times(1)
 	mockConfig.EXPECT().UpdateConfigFile(cred, gomock.Any(), "http://www.test.com", gomock.Any(), "default").Times(1)
 
-	mockRequest.EXPECT().RequestNewAccessKey("http://www.test.com/user/credentials/cdis/access_token", &cred).Times(1)
+	mockRequest.EXPECT().RequestNewAccessKey("http://www.test.com/user/credentials/api/access_token", &cred).Times(1)
 	mockRequest.EXPECT().GetPresignedURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockedResp).Times(2)
 
-	_, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid")
+	_, _, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", nil)
 
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "No GUID found in ") {
 		t.Fail()
 	}
 


### PR DESCRIPTION
This pr address JIRA ticket PXD-2218 https://jira.opensciencedatacloud.org/browse/PXD-2218

The gen3-client can now support the new upload flow.

General usage:
`./gen3-client upload-new --profile <profile-name> --upload-path=<path-to-files>`

Ticket PXD-2304 https://jira.opensciencedatacloud.org/browse/PXD-2304 has also been addressed in this pr.
The gen3-client can accept regex in the new upload flow command, sample usages:
`./gen3-client upload-new --profile <profile-name> --upload-path=<path-to-files/*.json>`
`./gen3-client upload-new --profile <profile-name> --upload-path=<path-to-files/*/folder/*>`
