### PR TITLE
option to include sub dir name in file name

### DIFF
--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -21,6 +21,7 @@ func ParseFilePaths(filePath string) ([]string, error) {
 	fmt.Println("\nBegin parsing all file paths for \"" + filePath + "\"")
 	fullFilePath := ParseRootPath(filePath)
 	filePaths, err := filepath.Glob(fullFilePath) // Generating all possible file paths
+
 	for _, filePath := range filePaths {
 		file, err := os.Open(filePath)
 		if err != nil {


### PR DESCRIPTION
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- For `upload`, a new option `include-subdirname` is added. If set to true, it will include subdir names as a part of filename.

Example:
```
├── pwd
│   └── dir2
│        └── data.dat
```
If set `--include-subdirname=true`, then the uploaded file name becomes `dir2/data.dat`

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

