### PR TITLE
fix/limit single file size to 5GB 

### DIFF
--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -108,6 +108,10 @@ func init() {
 			bars := make([]*pb.ProgressBar, 0)
 
 			for _, filePath := range filePaths {
+				if _, err := os.Stat(filePath); os.IsNotExist(err) {
+					log.Fatalf("The file you specified \"%s\" does not exist locally", filePath)
+				}
+
 				file, err := os.Open(filePath)
 				if err != nil {
 					log.Fatal("File open error")
@@ -151,13 +155,9 @@ func init() {
 					}
 				}
 
-				if _, err := os.Stat(filePath); os.IsNotExist(err) {
-					log.Fatalf("The file you specified \"%s\" does not exist locally", filePath)
-				}
-
 				req, bar, err := GenerateUploadRequest("", respURL, file)
 				if err != nil {
-					log.Fatalf("Error occurred during request generation: %s", err.Error())
+					log.Printf("Error occurred during request generation: %s", err.Error())
 					continue
 				}
 				if batch {


### PR DESCRIPTION
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- Due to limitation of S3, we need to restrict the file size for each file to be uploaded to a maximum of 5GB. For now gen3-client will notify user and skip those files. This restriction can be resolved after we support multipart upload

### Improvements


### Dependency updates


### Deployment changes

