### PR TITLE
Feat/multipart upload

### DIFF
--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -6,13 +6,19 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
-var PathSeparator = string(os.PathSeparator)
+// PathSeparator is os dependent path separator char
+const PathSeparator = string(os.PathSeparator)
 
+// DefaultTimeout is used to set timeout value for http client
+const DefaultTimeout = 30 * time.Second
+
+// FileUploadRequestObject defines a object for file upload
 type FileUploadRequestObject struct {
 	FilePath     string
 	Filename     string
@@ -22,13 +28,16 @@ type FileUploadRequestObject struct {
 	Bar          *pb.ProgressBar
 }
 
+// RetryObject defines a object for retry upload
 type RetryObject struct {
 	FilePath     string
 	GUID         string
 	PresignedURL string
 	RetryCount   int
+	Multipart    bool
 }
 
+// ParseRootPath parses dirname that has "~" in the beginning
 func ParseRootPath(filePath string) string {
 	if filePath != "" && filePath[0] == '~' {
 		homeDir, err := homedir.Dir()
@@ -40,6 +49,7 @@ func ParseRootPath(filePath string) string {
 	return filePath
 }
 
+// ParseFilePaths generates all possible file paths
 func ParseFilePaths(filePath string) ([]string, error) {
 	fmt.Println("\nBegin parsing all file paths for \"" + filePath + "\"")
 	fullFilePath := ParseRootPath(filePath)

--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -15,7 +15,7 @@ import (
 const PathSeparator = string(os.PathSeparator)
 
 // DefaultTimeout is used to set timeout value for http client
-const DefaultTimeout = 30 * time.Second
+const DefaultTimeout = 120 * time.Second
 
 // FileUploadRequestObject defines a object for file upload
 type FileUploadRequestObject struct {

--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -29,11 +29,10 @@ type FileUploadRequestObject struct {
 
 // RetryObject defines a object for retry upload
 type RetryObject struct {
-	FilePath     string
-	GUID         string
-	PresignedURL string
-	RetryCount   int
-	Multipart    bool
+	FilePath   string
+	GUID       string
+	RetryCount int
+	Multipart  bool
 }
 
 // ParseRootPath parses dirname that has "~" in the beginning

--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -1,7 +1,6 @@
 package commonUtils
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -51,7 +50,6 @@ func ParseRootPath(filePath string) string {
 
 // ParseFilePaths generates all possible file paths
 func ParseFilePaths(filePath string) ([]string, error) {
-	fmt.Println("\nBegin parsing all file paths for \"" + filePath + "\"")
 	fullFilePath := ParseRootPath(filePath)
 	filePaths, err := filepath.Glob(fullFilePath) // Generating all possible file paths
 
@@ -78,6 +76,6 @@ func ParseFilePaths(filePath string) ([]string, error) {
 		}
 		file.Close()
 	}
-	fmt.Println("Finish parsing all file paths for \"" + filePath + "\"")
+	log.Println("Finish parsing all file paths for \"" + filePath + "\"")
 	return filePaths, err
 }

--- a/gen3-client/g3cmd/auth.go
+++ b/gen3-client/g3cmd/auth.go
@@ -24,9 +24,7 @@ func init() {
 			function.Request = request
 			function.Config = configure
 
-			endPointPostfix := "/user/user" // Information about current user
-
-			host, projectAccess, err := function.CheckPrivileges(profile, "", endPointPostfix, "application/json", nil)
+			host, projectAccess, err := function.CheckPrivileges(profile, "")
 
 			if err != nil {
 				log.Fatalf("Fatal authentication error: %s\n", err)

--- a/gen3-client/g3cmd/download-manifest.go
+++ b/gen3-client/g3cmd/download-manifest.go
@@ -107,7 +107,7 @@ func init() {
 				reqs := make([]*grab.Request, 0)
 				for _, object := range objects {
 					endPointPostfix := "/user/data/download/" + object.ObjectID + protocolText
-					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
+					msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
 
 					if err != nil {
 						if strings.Contains(err.Error(), "The provided guid") {
@@ -115,10 +115,11 @@ func init() {
 						} else {
 							log.Fatalf("Fatal download error: %s\n", err)
 						}
+					} else if msg.URL == "" {
+						log.Printf("Error in getting download URL for object %s\n", object.ObjectID)
 					} else {
-						req, _ := grab.NewRequest(downloadPath+"/"+object.ObjectID, respURL)
-
-						if strings.Contains(respURL, "X-Amz-Signature") {
+						req, _ := grab.NewRequest(downloadPath+"/"+object.ObjectID, msg.URL)
+						if strings.Contains(msg.URL, "X-Amz-Signature") {
 							req.NoResume = true
 						}
 						reqs = append(reqs, req)
@@ -129,7 +130,7 @@ func init() {
 			} else {
 				for _, object := range objects {
 					endPointPostfix := "/user/data/download/" + object.ObjectID + protocolText
-					respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
+					msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
 
 					if err != nil {
 						if strings.Contains(err.Error(), "The provided guid") {
@@ -137,8 +138,10 @@ func init() {
 						} else {
 							log.Fatalf("Fatal download error: %s\n", err)
 						}
+					} else if msg.URL == "" {
+						log.Printf("Error in getting download URL for object %s\n", object.ObjectID)
 					} else {
-						downloadFile(object.ObjectID, downloadPath+"/"+object.ObjectID, respURL)
+						downloadFile(object.ObjectID, downloadPath+"/"+object.ObjectID, msg.URL)
 					}
 				}
 			}

--- a/gen3-client/g3cmd/download.go
+++ b/gen3-client/g3cmd/download.go
@@ -82,7 +82,7 @@ func init() {
 
 			endPointPostfix := "/user/data/download/" + guid + protocolText
 
-			respURL, _, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
+			msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
 
 			if err != nil {
 				if strings.Contains(err.Error(), "The provided guid") {
@@ -90,8 +90,10 @@ func init() {
 				} else {
 					log.Fatalf("Fatal download error: %s\n", err)
 				}
+			} else if msg.URL == "" {
+				log.Printf("Error in getting download URL for object %s\n", guid)
 			} else {
-				downloadFile(guid, filePath, respURL)
+				downloadFile(guid, filePath, msg.URL)
 			}
 		},
 	}

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -101,8 +101,9 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject, uploadPath str
 				file.Close()
 				continue
 			}
-			if fi.Size() > FileSizeLimit { // guard for files, always check fixe size during retry upload
+			if fi.Size() > FileSizeLimit { // guard for files, always check file size during retry upload
 				updateRetryObject(ro, furObject.FilePath, "", "", ro.RetryCount, true)
+				err = fmt.Errorf("File size for %s is greater than the single part upload limit, will retry using multipart upload", furObject.Filename)
 				handleFailedRetry(ro, retryObjCh, err, false)
 				file.Close()
 				continue

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -12,13 +12,6 @@ import (
 	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 )
 
-func checkToCloseChannel(channelName string, channel chan interface{}) {
-	if (len(channel)) == 0 {
-		close(channel)
-		log.Printf("%s channel has been close", channelName)
-	}
-}
-
 func updateRetryObject(ro commonUtils.RetryObject, filePath string, guid string, presignedUrl string, retryCount int, isMultipart bool) {
 	ro.FilePath = filePath
 	ro.GUID = guid
@@ -76,7 +69,7 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject, uploadPath str
 				updateRetryObject(ro, ro.FilePath, ro.GUID, ro.PresignedURL, ro.RetryCount, true)
 				handleFailedRetry(ro, retryObjCh, err, true)
 				continue
-			} else {
+			} else { // succeeded
 				logs.IncrementScore(ro.RetryCount)
 				if (len(retryObjCh)) == 0 {
 					close(retryObjCh)
@@ -123,6 +116,7 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject, uploadPath str
 			}
 			logs.DeleteFromFailedLogMap(furObject.FilePath, true)
 			logs.IncrementScore(ro.RetryCount)
+			file.Close()
 			if (len(retryObjCh)) == 0 {
 				close(retryObjCh)
 				log.Println("Retry channel has been closed")

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -13,11 +13,7 @@ import (
 	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 )
 
-// MaxRetryCount is the maximum retry number per record
-const MaxRetryCount = 5
-const maxWaitTime = 300
-
-func getWaitTime(retryCount int) time.Duration {
+func GetWaitTime(retryCount int) time.Duration {
 	exponentialWaitTime := math.Pow(2, float64(retryCount))
 	return time.Duration(math.Min(exponentialWaitTime, float64(maxWaitTime))) * time.Second
 }
@@ -102,8 +98,8 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject, includeSubDirN
 			continue
 		}
 
-		log.Printf("Sleep for %.0f seconds\n", getWaitTime(ro.RetryCount).Seconds())
-		time.Sleep(getWaitTime(ro.RetryCount)) // exponential wait for retry
+		log.Printf("Sleep for %.0f seconds\n", GetWaitTime(ro.RetryCount).Seconds())
+		time.Sleep(GetWaitTime(ro.RetryCount)) // exponential wait for retry
 		err = uploadFile(furObject, ro.RetryCount)
 		if err != nil {
 			ro.RetryCount++

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -67,7 +67,12 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject, uploadPath str
 		time.Sleep(GetWaitTime(ro.RetryCount)) // exponential wait for retry
 
 		if ro.GUID != "" {
-			//TODO: delete record
+			msg, err := DeleteRecord(ro.GUID)
+			if err == nil {
+				log.Println(msg)
+			} else {
+				log.Println(err.Error())
+			}
 		}
 
 		if ro.Multipart {

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -35,7 +35,7 @@ func handleFailedRetry(ro commonUtils.RetryObject, retryObjCh chan commonUtils.R
 	}
 }
 
-func retryUpload(failedLogMap map[string]commonUtils.RetryObject, uploadPath string, numParallel int, includeSubDirName bool) {
+func retryUpload(failedLogMap map[string]commonUtils.RetryObject, uploadPath string, includeSubDirName bool) {
 	var guid string
 	var filename string
 	var presignedURL string
@@ -76,7 +76,7 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject, uploadPath str
 		}
 
 		if ro.Multipart {
-			err = multipartUpload(uploadPath, ro.FilePath, numParallel, includeSubDirName, ro.RetryCount)
+			err = multipartUpload(uploadPath, ro.FilePath, includeSubDirName, ro.RetryCount)
 			if err != nil {
 				updateRetryObject(ro, ro.FilePath, ro.GUID, ro.RetryCount, true)
 				handleFailedRetry(ro, retryObjCh, err, true)
@@ -143,7 +143,6 @@ func init() {
 	var failedLogPath string
 	var includeSubDirName bool
 	var uploadPath string
-	var numParallel int
 	var retryUploadCmd = &cobra.Command{
 		Use:     "retry-upload",
 		Short:   "Retry upload file(s) to object storage.",
@@ -157,7 +156,7 @@ func init() {
 			failedLogPath = commonUtils.ParseRootPath(failedLogPath)
 			logs.LoadFailedLogFile(failedLogPath)
 			logs.InitScoreBoard(MaxRetryCount)
-			retryUpload(logs.GetFailedLogMap(), uploadPath, numParallel, includeSubDirName)
+			retryUpload(logs.GetFailedLogMap(), uploadPath, includeSubDirName)
 			logs.CloseAll()
 			logs.PrintScoreBoard()
 		},
@@ -166,7 +165,6 @@ func init() {
 	retryUploadCmd.Flags().StringVar(&failedLogPath, "failed-log-path", "", "The path to the failed log file.")
 	retryUploadCmd.MarkFlagRequired("failed-log-path")
 	retryUploadCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory or file in which contains file(s) to be uploaded")
-	retryUploadCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
 	retryUploadCmd.Flags().BoolVar(&includeSubDirName, "include-subdirname", false, "Include subdirectory names in file name")
 	RootCmd.AddCommand(retryUploadCmd)
 }

--- a/gen3-client/g3cmd/upload-manifest.go
+++ b/gen3-client/g3cmd/upload-manifest.go
@@ -73,7 +73,7 @@ func init() {
 					file, err := os.Open(furObject.FilePath)
 					if err != nil {
 						log.Println("File open error: " + err.Error())
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, false)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						continue
 					}
@@ -82,7 +82,7 @@ func init() {
 					furObject, err := GenerateUploadRequest(furObject, file)
 					if err != nil {
 						file.Close()
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, false)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						log.Printf("Error occurred during request generation: %s", err.Error())
 						continue

--- a/gen3-client/g3cmd/upload-manifest.go
+++ b/gen3-client/g3cmd/upload-manifest.go
@@ -73,7 +73,7 @@ func init() {
 					file, err := os.Open(furObject.FilePath)
 					if err != nil {
 						log.Println("File open error: " + err.Error())
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, false)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						continue
 					}
@@ -82,7 +82,7 @@ func init() {
 					furObject, err := GenerateUploadRequest(furObject, file)
 					if err != nil {
 						file.Close()
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, false)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						log.Printf("Error occurred during request generation: %s", err.Error())
 						continue

--- a/gen3-client/g3cmd/upload-manifest.go
+++ b/gen3-client/g3cmd/upload-manifest.go
@@ -73,7 +73,7 @@ func init() {
 					file, err := os.Open(furObject.FilePath)
 					if err != nil {
 						log.Println("File open error: " + err.Error())
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, true)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						continue
 					}
@@ -82,7 +82,7 @@ func init() {
 					furObject, err := GenerateUploadRequest(furObject, file)
 					if err != nil {
 						file.Close()
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, true)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						log.Printf("Error occurred during request generation: %s", err.Error())
 						continue

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -106,7 +106,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 					continue
 				}
 
-				var etag string
+				var eTag string
 				err = retry(MaxRetryCount, filePath, guid, func() (err error) {
 					req, err := http.NewRequest(http.MethodPut, presignedURL, bytes.NewReader(buf))
 					req.ContentLength = int64(n)
@@ -119,7 +119,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 					if resp.StatusCode != 200 {
 						err = errors.New("Upload request got a non-200 response with status code " + strconv.Itoa(resp.StatusCode))
 						return
-					} else if etag = resp.Header.Get("ETag"); etag == "" {
+					} else if eTag = resp.Header.Get("ETag"); eTag == "" {
 						err = errors.New("No ETag found in header")
 						return
 					}
@@ -132,7 +132,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 				}
 
 				multipartUploadLock.Lock() // to avoid racing conditions
-				parts = append(parts, (MultipartPartObject{PartNumber: chunkIndex, ETag: etag}))
+				parts = append(parts, (MultipartPartObject{PartNumber: chunkIndex, ETag: eTag}))
 				bar.Add(n)
 				multipartUploadLock.Unlock()
 			}

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -82,7 +82,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 			for chunkIndex := range chunkIndexCh {
 				var presignedURL string
 				err = retry(MaxRetryCount, filePath, guid, func() (err error) {
-					presignedURL, err = GenerateMultpartPresignedURL(key, uploadID, chunkIndex)
+					presignedURL, err = GenerateMultipartPresignedURL(key, uploadID, chunkIndex)
 					return
 				})
 				if err != nil {
@@ -160,7 +160,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 		return parts[i].PartNumber < parts[j].PartNumber // sort parts in ascending order
 	})
 
-	if err = CompleteMultpartUpload(key, uploadID, parts); err != nil {
+	if err = CompleteMultipartUpload(key, uploadID, parts); err != nil {
 		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: %s", filename, err.Error())
 		return err

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -26,7 +26,7 @@ func retry(attempts int, filePath string, guid string, f func() error) (err erro
 			return
 		}
 
-		logs.AddToFailedLogMap(filePath, guid, "", i, false) // we don't save presigned url for multipart upload
+		logs.AddToFailedLogMap(filePath, guid, "", i, false) // don't save presigned url for multipart upload
 
 		if i >= (attempts - 1) {
 			break
@@ -81,7 +81,7 @@ func multipartUpload(uploadPath string, filePath string, file *os.File, numParal
 					return
 				})
 				if err != nil {
-					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true)
 					log.Println(err.Error())
 					logs.IncrementScore(logs.ScoreBoardLen - 1)
 					return
@@ -100,7 +100,7 @@ func multipartUpload(uploadPath string, filePath string, file *os.File, numParal
 					return
 				})
 				if err != nil {
-					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true)
 					log.Println(err.Error())
 					logs.IncrementScore(logs.ScoreBoardLen - 1)
 					return
@@ -123,7 +123,7 @@ func multipartUpload(uploadPath string, filePath string, file *os.File, numParal
 					return
 				})
 				if err != nil {
-					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true)
 					log.Println(err.Error())
 					logs.IncrementScore(logs.ScoreBoardLen - 1)
 					return
@@ -147,18 +147,18 @@ func multipartUpload(uploadPath string, filePath string, file *os.File, numParal
 	bar.Finish()
 
 	if len(parts) != totalChunks {
-		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true)
 		log.Println("Total number of received ETags doesn't match the total number of chunks")
 		logs.IncrementScore(logs.ScoreBoardLen - 1)
 		return
 	}
 
 	sort.Slice(parts, func(i, j int) bool {
-		return parts[i].PartNumber < parts[j].PartNumber
+		return parts[i].PartNumber < parts[j].PartNumber // sort parts in ascending order
 	})
 
 	if err = CompleteMultpartUpload(key, uploadID, parts); err != nil {
-		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true)
 		log.Println(err.Error())
 		logs.IncrementScore(logs.ScoreBoardLen - 1)
 		return

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -60,7 +60,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 		return err
 	}
 
-	uploadID, guid, filename, err := InitMultpartUpload(uploadPath, filePath, includeSubDirName)
+	uploadID, guid, filename, err := InitMultipartUpload(uploadPath, filePath, includeSubDirName)
 	if err != nil {
 		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: %s", filename, err.Error())

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -103,7 +103,6 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 				if err != nil {
 					logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 					log.Println(err.Error())
-					multipartUploadLock.Unlock()
 					continue
 				}
 
@@ -129,7 +128,6 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 				if err != nil {
 					logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 					log.Println(err.Error())
-					multipartUploadLock.Unlock()
 					continue
 				}
 

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -42,27 +42,27 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	file, err := os.Open(filePath)
 	defer file.Close()
 	if err != nil {
-		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
+		logs.AddToFailedLogMap(filePath, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s due to file open error: %s", filePath, err.Error())
 		return err
 	}
 
 	fi, err := file.Stat()
 	if err != nil {
-		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
+		logs.AddToFailedLogMap(filePath, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: file stat error, file may be missing or unreadable because of permissions", fi.Name())
 		return err
 	}
 
 	if fi.Size() > MultipartFileSizeLimit {
-		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
+		logs.AddToFailedLogMap(filePath, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: the file size has exceeded the limit allowed and cannot be uploaded. The maximum allowed file size is 5TB", fi.Name())
 		return err
 	}
 
 	uploadID, guid, filename, err := InitMultipartUpload(uploadPath, filePath, includeSubDirName)
 	if err != nil {
-		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
+		logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: %s", filename, err.Error())
 		return err
 	}
@@ -86,7 +86,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 					return
 				})
 				if err != nil {
-					logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
+					logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 					log.Println(err.Error())
 					continue
 				}
@@ -101,7 +101,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 					return
 				})
 				if err != nil {
-					logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
+					logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 					log.Println(err.Error())
 					multipartUploadLock.Unlock()
 					continue
@@ -127,7 +127,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 					return
 				})
 				if err != nil {
-					logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
+					logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 					log.Println(err.Error())
 					multipartUploadLock.Unlock()
 					continue
@@ -151,7 +151,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	bar.Finish()
 
 	if len(parts) != numOfChunks {
-		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
+		logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: Total number of received ETags doesn't match the total number of chunks", filename)
 		return err
 	}
@@ -161,7 +161,7 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	})
 
 	if err = CompleteMultipartUpload(key, uploadID, parts); err != nil {
-		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
+		logs.AddToFailedLogMap(filePath, guid, retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: %s", filename, err.Error())
 		return err
 	}

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -38,7 +38,7 @@ func retry(attempts int, filePath string, guid string, f func() error) (err erro
 	return fmt.Errorf("After %d attempts, last error: %s", attempts, err)
 }
 
-func multipartUpload(uploadPath string, filePath string, numParallel int, includeSubDirName bool, retryCount int) error {
+func multipartUpload(uploadPath string, filePath string, includeSubDirName bool, retryCount int) error {
 	file, err := os.Open(filePath)
 	defer file.Close()
 	if err != nil {

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -1,0 +1,139 @@
+package g3cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/uc-cdis/gen3-client/gen3-client/logs"
+	pb "gopkg.in/cheggaaa/pb.v1"
+)
+
+func retry(attempts int, filePath string, guid string, f func() error) (err error) {
+	for i := 0; ; i++ {
+		err = f()
+		if err == nil {
+			return
+		}
+
+		logs.AddToFailedLogMap(filePath, guid, "", i, false) // we don't save presigned url for multipart upload
+
+		if i >= (attempts - 1) {
+			break
+		}
+
+		time.Sleep(GetWaitTime(i))
+
+		log.Println("retrying after error:", err)
+	}
+	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
+}
+
+func multipartUpload(uploadPath string, filePath string, file *os.File, includeSubDirName bool) {
+	fi, err := file.Stat()
+	if err != nil {
+		logs.AddToFailedLogMap(filePath, "", "", 0, false)
+		log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
+	}
+
+	if fi.Size() > MultipartFileSizeLimit {
+		logs.AddToFailedLogMap(filePath, "", "", 0, false)
+		log.Println("The file size of file " + fi.Name() + " exceeds the limit allowed and cannot be uploaded. The maximum allowed file size is 5TB.\n")
+	}
+
+	uploadID, guid, filename, err := InitMultpartUpload(uploadPath, filePath, includeSubDirName)
+	if err != nil {
+		logs.AddToFailedLogMap(filePath, guid, "", 0, false)
+		log.Println(err.Error())
+		return
+	}
+
+	totalChunks := int(fi.Size() / MultipartFileChunkSize) // this casting should be safe
+	if fi.Size()%MultipartFileChunkSize != 0 {
+		totalChunks++
+	}
+
+	bar := pb.New64(fi.Size()).SetUnits(pb.U_BYTES).SetRefreshRate(time.Millisecond * 10).Prefix(filename + " ")
+	bar.Start()
+	buf := make([]byte, MultipartFileChunkSize)
+	chunk := 1
+	key := guid + "/" + filename
+	var parts []MultipartPartObject
+	for chunk <= totalChunks {
+		var presignedURL string
+		err = retry(MaxRetryCount, filePath, guid, func() (err error) {
+			presignedURL, err = GenerateMultpartPresignedURL(key, uploadID, chunk)
+			return
+		})
+		if err != nil {
+			break
+		}
+
+		var n int
+		err = retry(MaxRetryCount, filePath, guid, func() (err error) {
+			n, err = file.ReadAt(buf[:cap(buf)], int64((chunk-1)*MultipartFileChunkSize))
+			buf = buf[:n]
+			if err == io.EOF { // finished reading
+				err = nil
+			}
+			return
+		})
+		if err != nil {
+			break
+		}
+
+		var etag string
+		err = retry(MaxRetryCount, filePath, guid, func() (err error) {
+			req, err := http.NewRequest(http.MethodPut, presignedURL, bytes.NewReader(buf))
+			req.ContentLength = int64(n)
+			client := &http.Client{}
+			resp, err := client.Do(req)
+			if err != nil {
+				err = errors.New("Error occurred during upload: " + err.Error())
+			}
+			if resp.StatusCode != 200 {
+				err = errors.New("Upload request got a non-200 response with status code " + strconv.Itoa(resp.StatusCode))
+			} else if etag = resp.Header.Get("ETag"); etag == "" {
+				err = errors.New("No ETag found in header")
+			}
+			return
+		})
+		if err != nil {
+			break
+		}
+
+		parts = append(parts, (MultipartPartObject{PartNumber: chunk, ETag: etag}))
+		bar.Add(n)
+		chunk++
+	}
+	bar.Finish()
+
+	if err != nil {
+		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, false) // we don't save presigned url for multipart upload
+		log.Println(err.Error())
+		logs.IncrementScore(logs.ScoreBoardLen - 1)
+		return
+	}
+
+	if len(parts) != totalChunks {
+		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, false) // we don't save presigned url for multipart upload
+		log.Println("Total number of received ETags doesn't match the total number of chunks")
+		logs.IncrementScore(logs.ScoreBoardLen - 1)
+		return
+	}
+
+	if err = CompleteMultpartUpload(key, uploadID, parts); err != nil {
+		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, false) // we don't save presigned url for multipart upload
+		log.Println(err.Error())
+		logs.IncrementScore(logs.ScoreBoardLen - 1)
+		return
+	}
+
+	logs.IncrementScore(0)
+}

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -56,7 +56,7 @@ func multipartUpload(uploadPath string, filePath string, includeSubDirName bool,
 
 	if fi.Size() > MultipartFileSizeLimit {
 		logs.AddToFailedLogMap(filePath, "", retryCount, true, true)
-		err = fmt.Errorf("FAILED multipart upload for %s: the file size has exceeded the limit allowed and cannot be uploaded. The maximum allowed file size is 5TB", fi.Name())
+		err = fmt.Errorf("FAILED multipart upload for %s: the file size has exceeded the limit allowed and cannot be uploaded. The maximum allowed file size is %s", fi.Name(), FormatSize(MultipartFileSizeLimit))
 		return err
 	}
 

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -8,12 +8,16 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
+
+var multipartUploadLock sync.Mutex
 
 func retry(attempts int, filePath string, guid string, f func() error) (err error) {
 	for i := 0; ; i++ {
@@ -35,21 +39,21 @@ func retry(attempts int, filePath string, guid string, f func() error) (err erro
 	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }
 
-func multipartUpload(uploadPath string, filePath string, file *os.File, includeSubDirName bool) {
+func multipartUpload(uploadPath string, filePath string, file *os.File, numParallel int, includeSubDirName bool) {
 	fi, err := file.Stat()
 	if err != nil {
-		logs.AddToFailedLogMap(filePath, "", "", 0, false)
+		logs.AddToFailedLogMap(filePath, "", "", 0, true)
 		log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 	}
 
 	if fi.Size() > MultipartFileSizeLimit {
-		logs.AddToFailedLogMap(filePath, "", "", 0, false)
+		logs.AddToFailedLogMap(filePath, "", "", 0, true)
 		log.Println("The file size of file " + fi.Name() + " exceeds the limit allowed and cannot be uploaded. The maximum allowed file size is 5TB.\n")
 	}
 
 	uploadID, guid, filename, err := InitMultpartUpload(uploadPath, filePath, includeSubDirName)
 	if err != nil {
-		logs.AddToFailedLogMap(filePath, guid, "", 0, false)
+		logs.AddToFailedLogMap(filePath, guid, "", 0, true)
 		log.Println(err.Error())
 		return
 	}
@@ -61,79 +65,108 @@ func multipartUpload(uploadPath string, filePath string, file *os.File, includeS
 
 	bar := pb.New64(fi.Size()).SetUnits(pb.U_BYTES).SetRefreshRate(time.Millisecond * 10).Prefix(filename + " ")
 	bar.Start()
-	buf := make([]byte, MultipartFileChunkSize)
-	chunk := 1
 	key := guid + "/" + filename
 	var parts []MultipartPartObject
-	for chunk <= totalChunks {
-		var presignedURL string
-		err = retry(MaxRetryCount, filePath, guid, func() (err error) {
-			presignedURL, err = GenerateMultpartPresignedURL(key, uploadID, chunk)
-			return
-		})
-		if err != nil {
-			break
-		}
 
-		var n int
-		err = retry(MaxRetryCount, filePath, guid, func() (err error) {
-			n, err = file.ReadAt(buf[:cap(buf)], int64((chunk-1)*MultipartFileChunkSize))
-			buf = buf[:n]
-			if err == io.EOF { // finished reading
-				err = nil
-			}
-			return
-		})
-		if err != nil {
-			break
-		}
+	wg := sync.WaitGroup{}
+	workers := getNumberOfWorkers(numParallel, totalChunks)
+	chunkIndexCh := make(chan int, totalChunks)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			for chunkIndex := range chunkIndexCh {
+				var presignedURL string
+				err = retry(MaxRetryCount, filePath, guid, func() (err error) {
+					presignedURL, err = GenerateMultpartPresignedURL(key, uploadID, chunkIndex)
+					return
+				})
+				if err != nil {
+					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+					log.Println(err.Error())
+					logs.IncrementScore(logs.ScoreBoardLen - 1)
+					return
+				}
 
-		var etag string
-		err = retry(MaxRetryCount, filePath, guid, func() (err error) {
-			req, err := http.NewRequest(http.MethodPut, presignedURL, bytes.NewReader(buf))
-			req.ContentLength = int64(n)
-			client := &http.Client{}
-			resp, err := client.Do(req)
-			if err != nil {
-				err = errors.New("Error occurred during upload: " + err.Error())
-			}
-			if resp.StatusCode != 200 {
-				err = errors.New("Upload request got a non-200 response with status code " + strconv.Itoa(resp.StatusCode))
-			} else if etag = resp.Header.Get("ETag"); etag == "" {
-				err = errors.New("No ETag found in header")
-			}
-			return
-		})
-		if err != nil {
-			break
-		}
+				var n int
+				buf := make([]byte, MultipartFileChunkSize)
+				err = retry(MaxRetryCount, filePath, guid, func() (err error) {
+					multipartUploadLock.Lock()
+					n, err = file.ReadAt(buf[:cap(buf)], int64((chunkIndex-1)*MultipartFileChunkSize))
+					buf = buf[:n]
+					multipartUploadLock.Unlock()
+					if err == io.EOF { // finished reading
+						err = nil
+					}
+					return
+				})
+				if err != nil {
+					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+					log.Println(err.Error())
+					logs.IncrementScore(logs.ScoreBoardLen - 1)
+					return
+				}
 
-		parts = append(parts, (MultipartPartObject{PartNumber: chunk, ETag: etag}))
-		bar.Add(n)
-		chunk++
+				var etag string
+				err = retry(MaxRetryCount, filePath, guid, func() (err error) {
+					req, err := http.NewRequest(http.MethodPut, presignedURL, bytes.NewReader(buf))
+					req.ContentLength = int64(n)
+					client := &http.Client{}
+					resp, err := client.Do(req)
+					if err != nil {
+						err = errors.New("Error occurred during upload: " + err.Error())
+					}
+					if resp.StatusCode != 200 {
+						err = errors.New("Upload request got a non-200 response with status code " + strconv.Itoa(resp.StatusCode))
+					} else if etag = resp.Header.Get("ETag"); etag == "" {
+						err = errors.New("No ETag found in header")
+					}
+					return
+				})
+				if err != nil {
+					logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
+					log.Println(err.Error())
+					logs.IncrementScore(logs.ScoreBoardLen - 1)
+					return
+				}
+
+				multipartUploadLock.Lock()
+				parts = append(parts, (MultipartPartObject{PartNumber: chunkIndex, ETag: etag}))
+				bar.Add(n)
+				multipartUploadLock.Unlock()
+			}
+			wg.Done()
+		}()
 	}
+
+	for i := 1; i <= totalChunks; i++ {
+		chunkIndexCh <- i
+	}
+	close(chunkIndexCh)
+
+	wg.Wait()
 	bar.Finish()
 
-	if err != nil {
-		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, false) // we don't save presigned url for multipart upload
-		log.Println(err.Error())
-		logs.IncrementScore(logs.ScoreBoardLen - 1)
-		return
-	}
-
 	if len(parts) != totalChunks {
-		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, false) // we don't save presigned url for multipart upload
+		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
 		log.Println("Total number of received ETags doesn't match the total number of chunks")
 		logs.IncrementScore(logs.ScoreBoardLen - 1)
 		return
 	}
 
+	sort.Slice(parts, func(i, j int) bool {
+		return parts[i].PartNumber < parts[j].PartNumber
+	})
+
 	if err = CompleteMultpartUpload(key, uploadID, parts); err != nil {
-		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, false) // we don't save presigned url for multipart upload
+		logs.AddToFailedLogMap(filePath, guid, "", MaxRetryCount, true) // we don't save presigned url for multipart upload
 		log.Println(err.Error())
 		logs.IncrementScore(logs.ScoreBoardLen - 1)
 		return
 	}
 
+	log.Printf("Successfully uploaded file \"%s\" to GUID %s.\n", filePath, guid)
+	logs.DeleteFromFailedLogMap(filePath, true)
+	logs.WriteToSucceededLog(filePath, guid, true)
+	logs.WriteToFailedLog()
 	logs.IncrementScore(0)
 }

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -42,13 +42,13 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	file, err := os.Open(filePath)
 	defer file.Close()
 	if err != nil {
-		logs.AddToFailedLogMap(filePath, "", "", retryCount, false, true)
+		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
 		log.Println("File open error: " + err.Error())
 	}
 
 	fi, err := file.Stat()
 	if err != nil {
-		logs.AddToFailedLogMap(filePath, "", "", retryCount, false, true)
+		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
 		log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 	}
 

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -44,7 +44,6 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	if err != nil {
 		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s due to file open error: %s", filePath, err.Error())
-		log.Println(err.Error())
 		return err
 	}
 
@@ -52,14 +51,12 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	if err != nil {
 		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: file stat error, file may be missing or unreadable because of permissions", fi.Name())
-		log.Println(err.Error())
 		return err
 	}
 
 	if fi.Size() > MultipartFileSizeLimit {
 		logs.AddToFailedLogMap(filePath, "", "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: the file size has exceeded the limit allowed and cannot be uploaded. The maximum allowed file size is 5TB", fi.Name())
-		log.Println(err.Error())
 		return err
 	}
 
@@ -67,7 +64,6 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	if err != nil {
 		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: %s", filename, err.Error())
-		log.Println(err.Error())
 		return err
 	}
 
@@ -162,7 +158,6 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	if len(parts) != totalChunks {
 		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: Total number of received ETags doesn't match the total number of chunks", filename)
-		log.Println(err.Error())
 		return err
 	}
 
@@ -173,7 +168,6 @@ func multipartUpload(uploadPath string, filePath string, numParallel int, includ
 	if err = CompleteMultpartUpload(key, uploadID, parts); err != nil {
 		logs.AddToFailedLogMap(filePath, guid, "", retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: %s", filename, err.Error())
-		log.Println(err.Error())
 		return err
 	}
 

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -38,7 +38,7 @@ func init() {
 				filePath = filePaths[0]
 			}
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {
-				logs.AddToFailedLogMap(filePath, "", "", 0, false)
+				logs.AddToFailedLogMap(filePath, "", "", 0, false, false)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -48,7 +48,7 @@ func init() {
 
 			file, err := os.Open(filePath)
 			if err != nil {
-				logs.AddToFailedLogMap(filePath, "", "", 0, false)
+				logs.AddToFailedLogMap(filePath, "", "", 0, false, false)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -62,7 +62,7 @@ func init() {
 			furObject, err = GenerateUploadRequest(furObject, file)
 			if err != nil {
 				file.Close()
-				logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false)
+				logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, false)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -38,7 +38,7 @@ func init() {
 				filePath = filePaths[0]
 			}
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {
-				logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+				logs.AddToFailedLogMap(filePath, "", 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -48,7 +48,7 @@ func init() {
 
 			file, err := os.Open(filePath)
 			if err != nil {
-				logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+				logs.AddToFailedLogMap(filePath, "", 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -62,7 +62,7 @@ func init() {
 			furObject, err = GenerateUploadRequest(furObject, file)
 			if err != nil {
 				file.Close()
-				logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, true)
+				logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -38,7 +38,7 @@ func init() {
 				filePath = filePaths[0]
 			}
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {
-				logs.AddToFailedLogMap(filePath, "", "", 0, false, false)
+				logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -48,7 +48,7 @@ func init() {
 
 			file, err := os.Open(filePath)
 			if err != nil {
-				logs.AddToFailedLogMap(filePath, "", "", 0, false, false)
+				logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -62,7 +62,7 @@ func init() {
 			furObject, err = GenerateUploadRequest(furObject, file)
 			if err != nil {
 				file.Close()
-				logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, false)
+				logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -116,7 +116,7 @@ func init() {
 			if len(multipartFilePaths) > 0 {
 				log.Println("Multipart uploading....")
 				for _, filePath := range multipartFilePaths {
-					err = multipartUpload(uploadPath, filePath, numParallel, includeSubDirName, 0)
+					err = multipartUpload(uploadPath, filePath, includeSubDirName, 0)
 					if err != nil {
 						log.Println(err.Error())
 					} else {
@@ -126,7 +126,7 @@ func init() {
 			}
 
 			if !logs.IsFailedLogMapEmpty() {
-				retryUpload(logs.GetFailedLogMap(), uploadPath, numParallel, includeSubDirName)
+				retryUpload(logs.GetFailedLogMap(), uploadPath, includeSubDirName)
 			}
 			logs.CloseAll()
 			logs.PrintScoreBoard()

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -117,7 +117,9 @@ func init() {
 				log.Println("Multipart uploading....")
 				for _, filePath := range multipartFilePaths {
 					err = multipartUpload(uploadPath, filePath, numParallel, includeSubDirName, 0)
-					if err == nil {
+					if err != nil {
+						log.Println(err.Error())
+					} else {
 						logs.IncrementScore(0)
 					}
 				}

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -15,6 +15,7 @@ func init() {
 	var includeSubDirName bool
 	var uploadPath string
 	var batch bool
+	var forceMultipart bool
 	var numParallel int
 	var uploadNewCmd = &cobra.Command{
 		Use:   "upload",
@@ -45,7 +46,7 @@ func init() {
 			}
 			fmt.Println()
 
-			singlepartFilePaths, multipartFilePaths := validateFilePath(filePaths)
+			singlepartFilePaths, multipartFilePaths := validateFilePath(filePaths, forceMultipart)
 
 			if batch {
 				workers, respCh, errCh, batchFURObjects := initBatchUploadChannels(numParallel, len(singlepartFilePaths))
@@ -146,5 +147,6 @@ func init() {
 	uploadNewCmd.Flags().BoolVar(&batch, "batch", false, "Upload in parallel")
 	uploadNewCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
 	uploadNewCmd.Flags().BoolVar(&includeSubDirName, "include-subdirname", false, "Include subdirectory names in file name")
+	uploadNewCmd.Flags().BoolVar(&forceMultipart, "force-multipart", false, "Force to use multipart upload if possible")
 	RootCmd.AddCommand(uploadNewCmd)
 }

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -129,7 +129,7 @@ func init() {
 						log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 						continue
 					}
-					multipartUpload(uploadPath, filePath, file, includeSubDirName)
+					multipartUpload(uploadPath, filePath, file, numParallel, includeSubDirName)
 				}
 			}
 

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -76,21 +76,21 @@ func init() {
 				for _, filePath := range singlepartFilePaths {
 					file, err := os.Open(filePath)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, "", 0, false, true)
 						log.Println("File open error: " + err.Error())
 						continue
 					}
 
 					fi, err := file.Stat()
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, "", 0, false, true)
 						log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 						continue
 					}
 					// The following flow is for singlepart upload flow
 					respURL, guid, filename, err := GeneratePresignedURL(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, guid, respURL, 0, false, true)
+						logs.AddToFailedLogMap(filePath, guid, 0, false, true)
 						log.Println(err.Error())
 						continue
 					}

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -76,21 +76,21 @@ func init() {
 				for _, filePath := range singlepartFilePaths {
 					file, err := os.Open(filePath)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, false)
+						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 						log.Println("File open error: " + err.Error())
 						continue
 					}
 
 					fi, err := file.Stat()
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, false)
+						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 						log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 						continue
 					}
 					// The following flow is for singlepart upload flow
 					respURL, guid, filename, err := GeneratePresignedURL(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, guid, respURL, 0, false, false)
+						logs.AddToFailedLogMap(filePath, guid, respURL, 0, false, true)
 						log.Println(err.Error())
 						continue
 					}

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -57,9 +57,7 @@ type FileInfo struct {
 }
 
 // FileSizeLimit is the maximun single file size for non-multipart upload (5GB)
-// const FileSizeLimit = 5 * 1024 * 1024 * 1024
-// TODO: change this back
-const FileSizeLimit = 50 * 1024 * 1024
+const FileSizeLimit = 5 * 1024 * 1024 * 1024
 
 // MultipartFileSizeLimit is the maximun single file size for multipart upload (5TB)
 const MultipartFileSizeLimit = 5 * 1024 * 1024 * 1024 * 1024
@@ -169,7 +167,7 @@ func GeneratePresignedURL(uploadPath string, filePath string, includeSubDirName 
 	return msg.URL, msg.GUID, fileinfo.Filename, err
 }
 
-// GenerateUploadRequest helps preparing the HTTP request for upload and the progress bar
+// GenerateUploadRequest helps preparing the HTTP request for upload and the progress bar for single part upload
 func GenerateUploadRequest(furObject commonUtils.FileUploadRequestObject, file *os.File) (commonUtils.FileUploadRequestObject, error) {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -56,14 +56,26 @@ type FileInfo struct {
 	Filename string
 }
 
+const (
+	_ = iota
+	// KB is kilobytes
+	KB int64 = 1 << (10 * iota)
+	// MB is megabytes
+	MB
+	// GB is gigabytes
+	GB
+	// TB is terrabytes
+	TB
+)
+
 // FileSizeLimit is the maximun single file size for non-multipart upload (5GB)
-const FileSizeLimit = 5 * 1024 * 1024 * 1024
+const FileSizeLimit = 5 * GB
 
 // MultipartFileSizeLimit is the maximun single file size for multipart upload (5TB)
-const MultipartFileSizeLimit = 5 * 1024 * 1024 * 1024 * 1024
+const MultipartFileSizeLimit = 5 * TB
 
-// MultipartFileChunkSize is the chunk size for each part for multipart upload (5MB)
-const MultipartFileChunkSize = 5 * 1024 * 1024
+// MultipartFileChunkSize is the chunk size for each part for multipart upload (500MB), since the Maximum number of parts per upload is 10,000
+const MultipartFileChunkSize = 500 * MB
 
 // MaxRetryCount is the maximum retry number per record
 const MaxRetryCount = 5
@@ -228,7 +240,7 @@ func GenerateUploadRequest(furObject commonUtils.FileUploadRequestObject, file *
 func validateFilePath(filePaths []string, forceMultipart bool) ([]string, []string) {
 	fileSizeLimit := FileSizeLimit // 5GB
 	if forceMultipart {
-		fileSizeLimit = MultipartFileChunkSize // 5MB
+		fileSizeLimit = MultipartFileChunkSize // 500MB
 	}
 	singlepartFilePaths := make([]string, 0)
 	multipartFilePaths := make([]string, 0)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -28,23 +28,26 @@ type ManifestObject struct {
 	SubjectID string `json:"subject_id"`
 }
 
-// RequestObject represents the payload that sends to fence for getting a presignedURL or init a multipart upload for new object file
-type MultipartInitRequestObject struct {
+// InitRequestObject represents the payload that sends to fence for getting a singlepart upload presignedURL or init a multipart upload for new object file
+type InitRequestObject struct {
 	Filename string `json:"file_name"`
 }
 
+// MultipartUploadRequestObject represents the payload that sends to fence for getting a presignedURL for a part
 type MultipartUploadRequestObject struct {
 	Key        string `json:"key"`
 	UploadID   string `json:"uploadId"`
 	PartNumber int    `json:"partNumber"`
 }
 
+// MultipartCompleteRequestObject represents the payload that sends to fence for completeing a multipart upload
 type MultipartCompleteRequestObject struct {
 	Key      string                `json:"key"`
 	UploadID string                `json:"uploadId"`
 	Parts    []MultipartPartObject `json:"parts"`
 }
 
+// MultipartPartObject represents a part object
 type MultipartPartObject struct {
 	PartNumber int    `json:"PartNumber"`
 	ETag       string `json:"ETag"`
@@ -81,6 +84,7 @@ const MultipartFileChunkSize = 500 * MB
 const MaxRetryCount = 5
 const maxWaitTime = 300
 
+// InitMultpartUpload helps sending requests to fence to init a multipart upload
 func InitMultpartUpload(uploadPath string, filePath string, includeSubDirName bool) (string, string, string, error) {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)
@@ -94,7 +98,7 @@ func InitMultpartUpload(uploadPath string, filePath string, includeSubDirName bo
 		log.Println(err.Error())
 	}
 	endPointPostfix := "/user/data/multipart/init"
-	multipartInitObject := MultipartInitRequestObject{Filename: fileinfo.Filename}
+	multipartInitObject := InitRequestObject{Filename: fileinfo.Filename}
 	objectBytes, err := json.Marshal(multipartInitObject)
 
 	msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "application/json", objectBytes)
@@ -108,6 +112,7 @@ func InitMultpartUpload(uploadPath string, filePath string, includeSubDirName bo
 	return msg.UploadID, msg.GUID, fileinfo.Filename, err
 }
 
+// GenerateMultpartPresignedURL helps sending requests to fence to get a presigned URL for a part during a multipart upload
 func GenerateMultpartPresignedURL(key string, uploadID string, partNumber int) (string, error) {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)
@@ -131,6 +136,7 @@ func GenerateMultpartPresignedURL(key string, uploadID string, partNumber int) (
 	return msg.PresignedURL, err
 }
 
+// CompleteMultpartUpload helps sending requests to fence to complete a multipart upload
 func CompleteMultpartUpload(key string, uploadID string, parts []MultipartPartObject) error {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)
@@ -165,7 +171,7 @@ func GeneratePresignedURL(uploadPath string, filePath string, includeSubDirName 
 		log.Println(err.Error())
 	}
 	endPointPostfix := "/user/data/upload"
-	purObject := MultipartInitRequestObject{Filename: fileinfo.Filename}
+	purObject := InitRequestObject{Filename: fileinfo.Filename}
 	objectBytes, err := json.Marshal(purObject)
 
 	msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "application/json", objectBytes)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -352,11 +352,16 @@ func uploadFile(furObject commonUtils.FileUploadRequestObject, retryCount int) e
 	return nil
 }
 
-func initBatchUploadChannels(numParallel int, inputSliceLen int) (int, chan *http.Response, chan error, []commonUtils.FileUploadRequestObject) {
+func getNumberOfWorkers(numParallel int, inputSliceLen int) int {
 	workers := numParallel
 	if workers < 1 || workers > inputSliceLen {
 		workers = inputSliceLen
 	}
+	return workers
+}
+
+func initBatchUploadChannels(numParallel int, inputSliceLen int) (int, chan *http.Response, chan error, []commonUtils.FileUploadRequestObject) {
+	workers := getNumberOfWorkers(numParallel, inputSliceLen)
 	respCh := make(chan *http.Response, inputSliceLen)
 	errCh := make(chan error, inputSliceLen)
 	batchFURSlice := make([]commonUtils.FileUploadRequestObject, 0)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -243,6 +243,19 @@ func GenerateUploadRequest(furObject commonUtils.FileUploadRequestObject, file *
 	return furObject, err
 }
 
+// DeleteRecord helps sending requests to fence to delete a record from indexd as well as its storage locations
+func DeleteRecord(guid string) (string, error) {
+	request := new(jwt.Request)
+	configure := new(jwt.Configure)
+	function := new(jwt.Functions)
+
+	function.Config = configure
+	function.Request = request
+
+	msg, err := function.DeleteRecord(profile, "", guid)
+	return msg, err
+}
+
 func validateFilePath(filePaths []string, forceMultipart bool) ([]string, []string) {
 	fileSizeLimit := FileSizeLimit // 5GB
 	if forceMultipart {

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -84,8 +84,8 @@ const defaultNumOfWorkers = 10
 const MaxRetryCount = 5
 const maxWaitTime = 300
 
-// InitMultpartUpload helps sending requests to fence to init a multipart upload
-func InitMultpartUpload(uploadPath string, filePath string, includeSubDirName bool) (string, string, string, error) {
+// InitMultipartUpload helps sending requests to fence to init a multipart upload
+func InitMultipartUpload(uploadPath string, filePath string, includeSubDirName bool) (string, string, string, error) {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)
 	function := new(jwt.Functions)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -338,13 +338,13 @@ func uploadFile(furObject commonUtils.FileUploadRequestObject, retryCount int) e
 	client := &http.Client{Timeout: commonUtils.DefaultTimeout}
 	resp, err := client.Do(furObject.Request)
 	if err != nil {
-		logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, retryCount, false, false)
+		logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, retryCount, false, true)
 		logs.WriteToFailedLog()
 		furObject.Bar.Finish()
 		return errors.New("Error occurred during upload: " + err.Error())
 	}
 	if resp.StatusCode != 200 {
-		logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, retryCount, false, false)
+		logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, furObject.PresignedURL, retryCount, false, true)
 		logs.WriteToFailedLog()
 		furObject.Bar.Finish()
 		return errors.New("Upload request got a non-200 response with status code " + strconv.Itoa(resp.StatusCode))

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -112,8 +112,8 @@ func InitMultipartUpload(uploadPath string, filePath string, includeSubDirName b
 	return msg.UploadID, msg.GUID, fileinfo.Filename, err
 }
 
-// GenerateMultpartPresignedURL helps sending requests to fence to get a presigned URL for a part during a multipart upload
-func GenerateMultpartPresignedURL(key string, uploadID string, partNumber int) (string, error) {
+// GenerateMultipartPresignedURL helps sending requests to fence to get a presigned URL for a part during a multipart upload
+func GenerateMultipartPresignedURL(key string, uploadID string, partNumber int) (string, error) {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)
 	function := new(jwt.Functions)
@@ -136,8 +136,8 @@ func GenerateMultpartPresignedURL(key string, uploadID string, partNumber int) (
 	return msg.PresignedURL, err
 }
 
-// CompleteMultpartUpload helps sending requests to fence to complete a multipart upload
-func CompleteMultpartUpload(key string, uploadID string, parts []MultipartPartObject) error {
+// CompleteMultipartUpload helps sending requests to fence to complete a multipart upload
+func CompleteMultipartUpload(key string, uploadID string, parts []MultipartPartObject) error {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)
 	function := new(jwt.Functions)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -226,7 +226,11 @@ func GenerateUploadRequest(furObject commonUtils.FileUploadRequestObject, file *
 	return furObject, err
 }
 
-func validateFilePath(filePaths []string) ([]string, []string) {
+func validateFilePath(filePaths []string, forceMultipart bool) ([]string, []string) {
+	fileSizeLimit := FileSizeLimit // 5GB
+	if forceMultipart {
+		fileSizeLimit = MultipartFileChunkSize // 5MB
+	}
 	singlepartFilePaths := make([]string, 0)
 	multipartFilePaths := make([]string, 0)
 	for _, filePath := range filePaths {
@@ -258,7 +262,7 @@ func validateFilePath(filePaths []string) ([]string, []string) {
 		if fi.Size() > MultipartFileSizeLimit {
 			log.Println("The file size of file " + fi.Name() + " exceeds the limit allowed and cannot be uploaded. The maximum allowed file size is 5TB.\n")
 			continue
-		} else if fi.Size() > FileSizeLimit {
+		} else if fi.Size() > int64(fileSizeLimit) {
 			multipartFilePaths = append(multipartFilePaths, filePath)
 		} else {
 			singlepartFilePaths = append(singlepartFilePaths, filePath)

--- a/gen3-client/gdcHmac/functions.go
+++ b/gen3-client/gdcHmac/functions.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/uc-cdis/gen3-client/gen3-client/commonUtils"
 )
 
 func SignedRequest(method string, url_string string, body io.Reader, content_type string, service string, access_key string, secret_key string) (*http.Response, error) {
@@ -13,7 +15,7 @@ func SignedRequest(method string, url_string string, body io.Reader, content_typ
 		return nil, err
 	}
 
-	client := &http.Client{Timeout: commonUtils.DefaultTimeout
+	client := &http.Client{Timeout: commonUtils.DefaultTimeout}
 
 	req, err := http.NewRequest(method, url_string, body)
 	if err != nil {

--- a/gen3-client/gdcHmac/functions.go
+++ b/gen3-client/gdcHmac/functions.go
@@ -13,7 +13,7 @@ func SignedRequest(method string, url_string string, body io.Reader, content_typ
 		return nil, err
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: commonUtils.DefaultTimeout
 
 	req, err := http.NewRequest(method, url_string, body)
 	if err != nil {

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -24,8 +24,8 @@ type Functions struct {
 }
 
 type FunctionInterface interface {
-	DoRequestWithSignedHeader(DoRequest, string, string, string, string, []byte) *http.Response
-	ParseFenceURLResponse(*http.Response)
+	DoRequestWithSignedHeader(DoRequest, string, string, string, string, []byte) (JsonMessage, error)
+	ParseFenceURLResponse(*http.Response) (JsonMessage, error)
 }
 
 type Request struct {
@@ -93,10 +93,10 @@ func (r *Request) RequestNewAccessKey(apiEndpoint string, cred *Credential) erro
 		return errors.New("Error occurred in RequestNewAccessKey: " + err.Error())
 	}
 
-	if m.Access_token == "" {
+	if m.AccessToken == "" {
 		return errors.New("Could not get new access key from response string: " + str)
 	}
-	cred.AccessKey = m.Access_token
+	cred.AccessKey = m.AccessToken
 	return nil
 }
 
@@ -183,7 +183,7 @@ func (f *Functions) GetResponse(profile string, configFileType string, endpointP
 	return prefixEndPoint, resp, nil
 }
 
-func (f *Functions) DoRequestWithSignedHeader(profile string, configFileType string, endpointPostPrefix string, contentType string, bodyBytes []byte) (string, string, error) {
+func (f *Functions) DoRequestWithSignedHeader(profile string, configFileType string, endpointPostPrefix string, contentType string, bodyBytes []byte) (JsonMessage, error) {
 	/*
 	   Do request with signed header. User may have more than one profile and use a profile to make a request
 	*/
@@ -192,11 +192,11 @@ func (f *Functions) DoRequestWithSignedHeader(profile string, configFileType str
 
 	_, resp, err := f.GetResponse(profile, configFileType, endpointPostPrefix, contentType, bodyBytes)
 	if err != nil {
-		return "", "", err
+		return msg, err
 	}
 
 	msg, err = f.ParseFenceURLResponse(resp)
-	return msg.Url, msg.GUID, err
+	return msg, err
 }
 
 func (f *Functions) CheckPrivileges(profile string, configFileType string, endpointPostPrefix string, contentType string, bodyBytes []byte) (string, map[string]interface{}, error) {

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -47,7 +47,7 @@ func (r *Request) MakeARequest(method string, apiEndpoint string, accessKey stri
 	if contentType != "" {
 		headers["Content-Type"] = contentType
 	}
-	client := &http.Client{}
+	client := &http.Client{Timeout: commonUtils.DefaultTimeout}
 	req, err := http.NewRequest(method, apiEndpoint, body)
 	if err != nil {
 		return nil, errors.New("Error occurred during generating HTTP request: " + err.Error())

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -199,14 +199,16 @@ func (f *Functions) DoRequestWithSignedHeader(profile string, configFileType str
 	return msg, err
 }
 
-func (f *Functions) CheckPrivileges(profile string, configFileType string, endpointPostPrefix string, contentType string, bodyBytes []byte) (string, map[string]interface{}, error) {
+func (f *Functions) CheckPrivileges(profile string, configFileType string) (string, map[string]interface{}, error) {
 	/*
 	   Return user privileges from specified profile
 	*/
 	var err error
 	var data map[string]interface{}
 
-	host, resp, err := f.GetResponse(profile, configFileType, endpointPostPrefix, contentType, bodyBytes)
+	endPointPostfix := "/user/user" // Information about current user
+
+	host, resp, err := f.GetResponse(profile, configFileType, endPointPostfix, "", nil)
 	if err != nil {
 		return "", nil, err
 	}

--- a/gen3-client/jwt/utils.go
+++ b/gen3-client/jwt/utils.go
@@ -11,12 +11,14 @@ type Message interface{}
 type Response interface{}
 
 type AccessTokenStruct struct {
-	Access_token string
+	AccessToken string `json:"access_token"`
 }
 
 type JsonMessage struct {
-	Url  string
-	GUID string
+	URL          string `json:"url"`
+	GUID         string `json:"guid"`
+	UploadID     string `json:"uploadId"`
+	PresignedURL string `json:"presigned_url"`
 }
 
 type DoRequest func(*http.Response) *http.Response

--- a/gen3-client/logs/failed.go
+++ b/gen3-client/logs/failed.go
@@ -75,10 +75,10 @@ func GetFailedLogMap() map[string]commonUtils.RetryObject {
 	return failedLogFileMap
 }
 
-func AddToFailedLogMap(filePath string, guid string, presignedUrl string, retryCount int, isMultipart bool, isMuted bool) {
+func AddToFailedLogMap(filePath string, guid string, retryCount int, isMultipart bool, isMuted bool) {
 	failedLogLock.Lock()
 	defer failedLogLock.Unlock()
-	failedLogFileMap[filePath] = commonUtils.RetryObject{FilePath: filePath, GUID: guid, PresignedURL: presignedUrl, RetryCount: retryCount, Multipart: isMultipart}
+	failedLogFileMap[filePath] = commonUtils.RetryObject{FilePath: filePath, GUID: guid, RetryCount: retryCount, Multipart: isMultipart}
 	if !isMuted {
 		log.Printf("Failed file entry added for %s\n", filePath)
 	}

--- a/gen3-client/logs/failed.go
+++ b/gen3-client/logs/failed.go
@@ -75,10 +75,10 @@ func GetFailedLogMap() map[string]commonUtils.RetryObject {
 	return failedLogFileMap
 }
 
-func AddToFailedLogMap(filePath string, guid string, presignedUrl string, retryCount int, isMuted bool) {
+func AddToFailedLogMap(filePath string, guid string, presignedUrl string, retryCount int, isMultipart bool, isMuted bool) {
 	failedLogLock.Lock()
 	defer failedLogLock.Unlock()
-	failedLogFileMap[filePath] = commonUtils.RetryObject{FilePath: filePath, GUID: guid, PresignedURL: presignedUrl, RetryCount: retryCount}
+	failedLogFileMap[filePath] = commonUtils.RetryObject{FilePath: filePath, GUID: guid, PresignedURL: presignedUrl, RetryCount: retryCount, Multipart: isMultipart}
 	if !isMuted {
 		log.Printf("Failed file entry added for %s\n", filePath)
 	}

--- a/gen3-client/logs/scoreboard.go
+++ b/gen3-client/logs/scoreboard.go
@@ -25,7 +25,7 @@ func PrintScoreBoard() {
 			if i < 2 {
 				fmt.Fprintf(w, "Finished with %d retry \t %d\n", i, score)
 			} else if i < len(scoreBoard)-1 {
-				fmt.Fprintf(w, "Finished with %d retry(ies) \t %d\n", i, score)
+				fmt.Fprintf(w, "Finished with %d retries \t %d\n", i, score)
 			} else {
 				fmt.Fprintf(w, "Failed \t %d\n", scoreBoard[len(scoreBoard)-1])
 			}

--- a/gen3-client/logs/scoreboard.go
+++ b/gen3-client/logs/scoreboard.go
@@ -22,7 +22,7 @@ func PrintScoreBoard() {
 		fmt.Println("\n\nSubmission Results")
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 0, ' ', tabwriter.Debug)
 		for i, score := range scoreBoard {
-			if i < 2 {
+			if i == 1 {
 				fmt.Fprintf(w, "Finished with %d retry \t %d\n", i, score)
 			} else if i < len(scoreBoard)-1 {
 				fmt.Fprintf(w, "Finished with %d retries \t %d\n", i, score)

--- a/gen3-client/logs/scoreboard.go
+++ b/gen3-client/logs/scoreboard.go
@@ -22,7 +22,9 @@ func PrintScoreBoard() {
 		fmt.Println("\n\nSubmission Results")
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 0, ' ', tabwriter.Debug)
 		for i, score := range scoreBoard {
-			if i < len(scoreBoard)-1 {
+			if i < 2 {
+				fmt.Fprintf(w, "Finished with %d retry \t %d\n", i, score)
+			} else if i < len(scoreBoard)-1 {
 				fmt.Fprintf(w, "Finished with %d retry(ies) \t %d\n", i, score)
 			} else {
 				fmt.Fprintf(w, "Failed \t %d\n", scoreBoard[len(scoreBoard)-1])

--- a/tests/functions_test.go
+++ b/tests/functions_test.go
@@ -29,7 +29,7 @@ func TestDoRequestWithSignedHeaderNoProfile(t *testing.T) {
 
 	mockConfig.EXPECT().ParseConfig(gomock.Any()).Return(cred).Times(1)
 
-	_, _, err := testFunction.DoRequestWithSignedHeader("default", "not_json", "/user/data/download/test_uuid", "", nil)
+	_, err := testFunction.DoRequestWithSignedHeader("default", "not_json", "/user/data/download/test_uuid", "", nil)
 
 	if err == nil {
 		t.Fail()
@@ -53,7 +53,7 @@ func TestDoRequestWithSignedHeaderGoodToken(t *testing.T) {
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
 	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/data/download/test_uuid", "non_exprired_token", "", gomock.Any()).Return(mockedResp, nil).Times(1)
 
-	_, _, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", "", nil)
+	_, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", "", nil)
 
 	if err != nil {
 		t.Fail()
@@ -82,7 +82,7 @@ func TestDoRequestWithSignedHeaderCreateNewToken(t *testing.T) {
 	mockRequest.EXPECT().RequestNewAccessKey("http://www.test.com/user/credentials/api/access_token", &cred).Return(nil).Times(1)
 	mockRequest.EXPECT().MakeARequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
 
-	_, _, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", "", nil)
+	_, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", "", nil)
 
 	if err != nil {
 		t.Fail()
@@ -111,7 +111,7 @@ func TestDoRequestWithSignedHeaderRefreshToken(t *testing.T) {
 	mockRequest.EXPECT().RequestNewAccessKey("http://www.test.com/user/credentials/api/access_token", &cred).Return(nil).Times(1)
 	mockRequest.EXPECT().MakeARequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(2)
 
-	_, _, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", "", nil)
+	_, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", "", nil)
 
 	if err != nil && !strings.Contains(err.Error(), "401") {
 		t.Fail()

--- a/tests/functions_test.go
+++ b/tests/functions_test.go
@@ -131,7 +131,7 @@ func TestCheckPrivilegesNoProfile(t *testing.T) {
 
 	mockConfig.EXPECT().ParseConfig(gomock.Any()).Return(cred).Times(1)
 
-	_, _, err := testFunction.CheckPrivileges("default", "", "/user/user", "", nil)
+	_, _, err := testFunction.CheckPrivileges("default", "")
 
 	if err == nil {
 		t.Errorf("Expected an error on missing credentials in configuration, but not received")
@@ -156,7 +156,7 @@ func TestCheckPrivilegesNoAccess(t *testing.T) {
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
 	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_exprired_token", "", gomock.Any()).Return(mockedResp, nil).Times(1)
 
-	_, receivedAccess, err := testFunction.CheckPrivileges("default", "", "/user/user", "", nil)
+	_, receivedAccess, err := testFunction.CheckPrivileges("default", "")
 
 	expectedAccess := make(map[string]interface{})
 
@@ -195,7 +195,7 @@ func TestCheckPrivilegesGrantedAccess(t *testing.T) {
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
 	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_exprired_token", "", gomock.Any()).Return(mockedResp, nil).Times(1)
 
-	_, expectedAccess, err := testFunction.CheckPrivileges("default", "", "/user/user", "", nil)
+	_, expectedAccess, err := testFunction.CheckPrivileges("default", "")
 
 	receivedAccess := make(map[string]interface{})
 	receivedAccess["test_project"] = map[string]interface{}{


### PR DESCRIPTION
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented multipart upload feature for `upload` command
- Multipart upload will only works for `upload` and `retry-upload` command
- Optional `force-multipart` flag for `upload` command to force using multipart upload on files > 5MB, rather than the default limit which is on files > 5GB


### Breaking Changes


### Bug Fixes


### Improvements
- Temporary reducing console printouts, will add `verbose` option flag in the future


### Dependency updates


### Deployment changes

