### PR TITLE
Fix/singlepart timeout

### DIFF
--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -17,8 +17,8 @@ const PathSeparator = string(os.PathSeparator)
 // DefaultTimeout is used to set timeout value for http client
 const DefaultTimeout = 120 * time.Second
 
-// MultipartTimeout is used to set timeout value for http client doing multipart upload
-const MultipartTimeout = 3600 * time.Second
+// UploadTimeout is used to set timeout value for http client doing upload
+const UploadTimeout = 3600 * time.Second
 
 // FileUploadRequestObject defines a object for file upload
 type FileUploadRequestObject struct {

--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -17,6 +17,9 @@ const PathSeparator = string(os.PathSeparator)
 // DefaultTimeout is used to set timeout value for http client
 const DefaultTimeout = 120 * time.Second
 
+// MultipartTimeout is used to set timeout value for http client doing multipart upload
+const MultipartTimeout = 3600 * time.Second
+
 // FileUploadRequestObject defines a object for file upload
 type FileUploadRequestObject struct {
 	FilePath     string

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -27,6 +27,14 @@ func handleFailedRetry(ro commonUtils.RetryObject, retryObjCh chan commonUtils.R
 	if ro.RetryCount < MaxRetryCount { // try another time
 		retryObjCh <- ro
 	} else {
+		if ro.GUID != "" {
+			msg, err := DeleteRecord(ro.GUID)
+			if err == nil {
+				log.Println(msg)
+			} else {
+				log.Println(err.Error())
+			}
+		}
 		logs.IncrementScore(logs.ScoreBoardLen - 1) // inevitable failure
 		if (len(retryObjCh)) == 0 {
 			close(retryObjCh)

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -110,7 +110,7 @@ func multipartUpload(uploadPath string, filePath string, includeSubDirName bool,
 				err = retry(MaxRetryCount, filePath, guid, func() (err error) {
 					req, err := http.NewRequest(http.MethodPut, presignedURL, bytes.NewReader(buf))
 					req.ContentLength = int64(n)
-					client := &http.Client{Timeout: commonUtils.DefaultTimeout}
+					client := &http.Client{Timeout: commonUtils.MultipartTimeout}
 					resp, err := client.Do(req)
 					if err != nil {
 						err = errors.New("Error occurred during upload: " + err.Error())

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -110,7 +110,7 @@ func multipartUpload(uploadPath string, filePath string, includeSubDirName bool,
 				err = retry(MaxRetryCount, filePath, guid, func() (err error) {
 					req, err := http.NewRequest(http.MethodPut, presignedURL, bytes.NewReader(buf))
 					req.ContentLength = int64(n)
-					client := &http.Client{Timeout: commonUtils.MultipartTimeout}
+					client := &http.Client{Timeout: commonUtils.UploadTimeout}
 					resp, err := client.Do(req)
 					if err != nil {
 						err = errors.New("Error occurred during upload: " + err.Error())

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -374,7 +374,7 @@ func uploadFile(furObject commonUtils.FileUploadRequestObject, retryCount int) e
 	log.Println("Uploading data ...")
 	furObject.Bar.Start()
 
-	client := &http.Client{Timeout: commonUtils.DefaultTimeout}
+	client := &http.Client{}
 	resp, err := client.Do(furObject.Request)
 	if err != nil {
 		logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, retryCount, false, true)
@@ -484,7 +484,7 @@ func batchUpload(uploadPath string, includeSubDirName bool, furObjects []commonU
 		return
 	}
 
-	client := &http.Client{Timeout: commonUtils.DefaultTimeout}
+	client := &http.Client{}
 	wg := sync.WaitGroup{}
 	for i := 0; i < workers; i++ {
 		wg.Add(1)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -374,7 +374,7 @@ func uploadFile(furObject commonUtils.FileUploadRequestObject, retryCount int) e
 	log.Println("Uploading data ...")
 	furObject.Bar.Start()
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: commonUtils.UploadTimeout}
 	resp, err := client.Do(furObject.Request)
 	if err != nil {
 		logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, retryCount, false, true)
@@ -484,7 +484,7 @@ func batchUpload(uploadPath string, includeSubDirName bool, furObjects []commonU
 		return
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: commonUtils.UploadTimeout}
 	wg := sync.WaitGroup{}
 	for i := 0; i < workers; i++ {
 		wg.Add(1)


### PR DESCRIPTION
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- Upload requests now have longer timeouts (3600s)
- Remove record from indexd and storage on inevitable failure


### Improvements


### Dependency updates


### Deployment changes

