### PR TITLE
Fix/required vars

### DIFF
--- a/gen3-client/g3cmd/configure.go
+++ b/gen3-client/g3cmd/configure.go
@@ -30,6 +30,9 @@ func init() {
 			conf.UpdateConfigFile(cred, content, apiEndpoint, configPath, profile)
 		},
 	}
+
+	configureCmd.Flags().StringVar(&profile, "profile", "", "Specify profile to use")
+	configureCmd.MarkFlagRequired("profile")
 	configureCmd.Flags().StringVar(&credFile, "cred", "", "Specify the credential file that you want to use")
 	configureCmd.MarkFlagRequired("cred")
 	configureCmd.Flags().StringVar(&apiEndpoint, "apiendpoint", "", "Specify the API endpoint of the data commons")

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -203,10 +203,6 @@ func init() {
 				log.Fatalln("Error occurred during parsing config file for hostname: " + err.Error())
 			}
 			dataExplorerURL := host.Scheme + "://" + host.Host + "/explorer"
-			if manifestPath == "" {
-				log.Println("Required flag \"manifest\" not set")
-				log.Fatalln("A valid manifest can be acquired by using the \"Download Manifest\" button on " + dataExplorerURL)
-			}
 
 			downloadPath = commonUtils.ParseRootPath(downloadPath)
 			if !strings.HasSuffix(downloadPath, "/") {
@@ -235,11 +231,12 @@ func init() {
 		},
 	}
 
-	downloadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from")
+	downloadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from. A valid manifest can be acquired by using the \"Download Manifest\" button in Data Explorer for Common portal")
+	downloadMultipleCmd.MarkFlagRequired("manifest")
 	downloadMultipleCmd.Flags().StringVar(&downloadPath, "download-path", ".", "The directory in which to store the downloaded files")
-	downloadMultipleCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\" (default: original)")
+	downloadMultipleCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\"")
 	downloadMultipleCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Only useful when \"--filename-format=original\", will overwrite any duplicates in \"download-path\" if set to true, will rename file by appending a counter value to its filename otherwise (default: false)")
 	downloadMultipleCmd.Flags().StringVar(&protocol, "protocol", "", "Specify the preferred protocol with --protocol=s3 (default: \"\")")
-	downloadMultipleCmd.Flags().IntVar(&numParallel, "numparallel", 1, "Number of downloads to run in parallel (default: 1)")
+	downloadMultipleCmd.Flags().IntVar(&numParallel, "numparallel", 1, "Number of downloads to run in parallel")
 	RootCmd.AddCommand(downloadMultipleCmd)
 }

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -231,7 +231,7 @@ func init() {
 		},
 	}
 
-	downloadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from. A valid manifest can be acquired by using the \"Download Manifest\" button in Data Explorer for Common portal")
+	downloadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from. A valid manifest can be acquired by using the \"Download Manifest\" button in Data Explorer from a data common's portal")
 	downloadMultipleCmd.MarkFlagRequired("manifest")
 	downloadMultipleCmd.Flags().StringVar(&downloadPath, "download-path", ".", "The directory in which to store the downloaded files")
 	downloadMultipleCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\"")

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -232,6 +232,8 @@ func init() {
 		},
 	}
 
+	downloadMultipleCmd.Flags().StringVar(&profile, "profile", "", "Specify profile to use")
+	downloadMultipleCmd.MarkFlagRequired("profile")
 	downloadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from. A valid manifest can be acquired by using the \"Download Manifest\" button in Data Explorer from a data common's portal")
 	downloadMultipleCmd.MarkFlagRequired("manifest")
 	downloadMultipleCmd.Flags().StringVar(&downloadPath, "download-path", ".", "The directory in which to store the downloaded files")

--- a/gen3-client/g3cmd/download-single.go
+++ b/gen3-client/g3cmd/download-single.go
@@ -43,6 +43,7 @@ func init() {
 		},
 	}
 
+	downloadSingleCmd.Flags().StringVar(&profile, "profile", "", "Specify profile to use")
 	downloadSingleCmd.MarkFlagRequired("profile")
 	downloadSingleCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
 	downloadSingleCmd.MarkFlagRequired("guid")

--- a/gen3-client/g3cmd/download-single.go
+++ b/gen3-client/g3cmd/download-single.go
@@ -16,7 +16,7 @@ func init() {
 	var overwrite bool
 	var noPrompt bool
 
-	var downloadCmd = &cobra.Command{
+	var downloadSingleCmd = &cobra.Command{
 		Use:     "download-single",
 		Short:   "Download a single file from a GUID",
 		Long:    `Gets a presigned URL for a file from a GUID and then downloads the specified file.`,
@@ -43,12 +43,13 @@ func init() {
 		},
 	}
 
-	downloadCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
-	downloadCmd.MarkFlagRequired("guid")
-	downloadCmd.Flags().StringVar(&downloadPath, "download-path", ".", "The directory in which to store the downloaded files")
-	downloadCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\"")
-	downloadCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Only useful when \"--filename-format=original\", will overwrite any duplicates in \"download-path\" if set to true, will rename file by appending a counter value to its filename otherwise (default: false)")
-	downloadCmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "If set to true, will not display user prompt message for confirmation (default: false)")
-	downloadCmd.Flags().StringVar(&protocol, "protocol", "", "Specify the preferred protocol with --protocol=gs (default: \"\")")
-	RootCmd.AddCommand(downloadCmd)
+	downloadSingleCmd.MarkFlagRequired("profile")
+	downloadSingleCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
+	downloadSingleCmd.MarkFlagRequired("guid")
+	downloadSingleCmd.Flags().StringVar(&downloadPath, "download-path", ".", "The directory in which to store the downloaded files")
+	downloadSingleCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\"")
+	downloadSingleCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Only useful when \"--filename-format=original\", will overwrite any duplicates in \"download-path\" if set to true, will rename file by appending a counter value to its filename otherwise (default: false)")
+	downloadSingleCmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "If set to true, will not display user prompt message for confirmation (default: false)")
+	downloadSingleCmd.Flags().StringVar(&protocol, "protocol", "", "Specify the preferred protocol with --protocol=gs (default: \"\")")
+	RootCmd.AddCommand(downloadSingleCmd)
 }

--- a/gen3-client/g3cmd/download-single.go
+++ b/gen3-client/g3cmd/download-single.go
@@ -45,7 +45,7 @@ func init() {
 	downloadCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
 	downloadCmd.MarkFlagRequired("guid")
 	downloadCmd.Flags().StringVar(&downloadPath, "download-path", ".", "The directory in which to store the downloaded files")
-	downloadCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\" (default: original)")
+	downloadCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\"")
 	downloadCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Only useful when \"--filename-format=original\", will overwrite any duplicates in \"download-path\" if set to true, will rename file by appending a counter value to its filename otherwise (default: false)")
 	downloadCmd.Flags().StringVar(&protocol, "protocol", "", "Specify the preferred protocol with --protocol=gs (default: \"\")")
 	RootCmd.AddCommand(downloadCmd)

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -170,6 +170,8 @@ func init() {
 		},
 	}
 
+	retryUploadCmd.Flags().StringVar(&profile, "profile", "", "Specify profile to use")
+	retryUploadCmd.MarkFlagRequired("profile")
 	retryUploadCmd.Flags().StringVar(&failedLogPath, "failed-log-path", "", "The path to the failed log file.")
 	retryUploadCmd.MarkFlagRequired("failed-log-path")
 	retryUploadCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory or file in which contains file(s) to be uploaded")

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -35,7 +35,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	// Define flags and configuration settings.
-	RootCmd.PersistentFlags().StringVar(&profile, "profile", "", "Specify profile to add or edit with --profile=<profile-name>")
+	RootCmd.PersistentFlags().StringVar(&profile, "profile", "", "Specify profile to use")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -35,7 +35,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	// Define flags and configuration settings.
-	RootCmd.PersistentFlags().StringVar(&profile, "profile", "default", "Specify profile to add or edit with --profile=<profile-name>")
+	RootCmd.PersistentFlags().StringVar(&profile, "profile", "", "Specify profile to add or edit with --profile=<profile-name>")
+	RootCmd.MarkPersistentFlagRequired("profile")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -36,7 +36,6 @@ func init() {
 
 	// Define flags and configuration settings.
 	RootCmd.PersistentFlags().StringVar(&profile, "profile", "", "Specify profile to add or edit with --profile=<profile-name>")
-	RootCmd.MarkPersistentFlagRequired("profile")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -120,6 +120,8 @@ func init() {
 		},
 	}
 
+	uploadMultipleCmd.Flags().StringVar(&profile, "profile", "", "Specify profile to use")
+	uploadMultipleCmd.MarkFlagRequired("profile")
 	uploadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from. A valid manifest can be acquired by using the \"Download Manifest\" button in Data Explorer for Common portal")
 	uploadMultipleCmd.MarkFlagRequired("manifest")
 	uploadMultipleCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory in which contains files to be uploaded")

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -47,10 +47,6 @@ func init() {
 				log.Fatalln("Error occurred during parsing config file for hostname: " + err.Error())
 			}
 			dataExplorerURL := host.Scheme + "://" + host.Host + "/explorer"
-			if manifestPath == "" {
-				log.Println("Required flag \"manifest\" not set")
-				log.Fatalln("A valid manifest can be acquired by using the \"Download Manifest\" button on " + dataExplorerURL)
-			}
 
 			var objects []ManifestObject
 
@@ -124,10 +120,10 @@ func init() {
 		},
 	}
 
-	uploadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from")
+	uploadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from. A valid manifest can be acquired by using the \"Download Manifest\" button in Data Explorer for Common portal")
 	uploadMultipleCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory in which contains files to be uploaded")
 	uploadMultipleCmd.MarkFlagRequired("upload-path")
-	uploadMultipleCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel (default: true)")
-	uploadMultipleCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel (default: 3)")
+	uploadMultipleCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")
+	uploadMultipleCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
 	RootCmd.AddCommand(uploadMultipleCmd)
 }

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -121,6 +121,7 @@ func init() {
 	}
 
 	uploadMultipleCmd.Flags().StringVar(&manifestPath, "manifest", "", "The manifest file to read from. A valid manifest can be acquired by using the \"Download Manifest\" button in Data Explorer for Common portal")
+	uploadMultipleCmd.MarkFlagRequired("manifest")
 	uploadMultipleCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory in which contains files to be uploaded")
 	uploadMultipleCmd.MarkFlagRequired("upload-path")
 	uploadMultipleCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -82,6 +82,8 @@ func init() {
 		},
 	}
 
+	uploadSingleCmd.Flags().StringVar(&profile, "profile", "", "Specify profile to use")
+	uploadSingleCmd.MarkFlagRequired("profile")
 	uploadSingleCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
 	uploadSingleCmd.MarkFlagRequired("guid")
 	uploadSingleCmd.Flags().StringVar(&filePath, "file", "", "Specify file to upload to with --file=~/path/to/file")

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -17,7 +17,7 @@ func init() {
 	var guid string
 	var filePath string
 
-	var uploadCmd = &cobra.Command{
+	var uploadSingleCmd = &cobra.Command{
 		Use:     "upload-single",
 		Short:   "Upload a single file to a GUID",
 		Long:    `Gets a presigned URL for which to upload a file associated with a GUID and then uploads the specified file.`,
@@ -82,9 +82,9 @@ func init() {
 		},
 	}
 
-	uploadCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
-	uploadCmd.MarkFlagRequired("guid")
-	uploadCmd.Flags().StringVar(&filePath, "file", "", "Specify file to upload to with --file=~/path/to/file")
-	uploadCmd.MarkFlagRequired("file")
-	RootCmd.AddCommand(uploadCmd)
+	uploadSingleCmd.Flags().StringVar(&guid, "guid", "", "Specify the guid for the data you would like to work with")
+	uploadSingleCmd.MarkFlagRequired("guid")
+	uploadSingleCmd.Flags().StringVar(&filePath, "file", "", "Specify file to upload to with --file=~/path/to/file")
+	uploadSingleCmd.MarkFlagRequired("file")
+	RootCmd.AddCommand(uploadSingleCmd)
 }

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -17,7 +17,7 @@ func init() {
 	var batch bool
 	var forceMultipart bool
 	var numParallel int
-	var uploadNewCmd = &cobra.Command{
+	var uploadCmd = &cobra.Command{
 		Use:   "upload",
 		Short: "Upload file(s) to object storage.",
 		Long:  `Gets a presigned URL for each file and then uploads the specified file(s).`,
@@ -133,11 +133,11 @@ func init() {
 		},
 	}
 
-	uploadNewCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory or file in which contains file(s) to be uploaded")
-	uploadNewCmd.MarkFlagRequired("upload-path")
-	uploadNewCmd.Flags().BoolVar(&batch, "batch", false, "Upload in parallel")
-	uploadNewCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
-	uploadNewCmd.Flags().BoolVar(&includeSubDirName, "include-subdirname", false, "Include subdirectory names in file name")
-	uploadNewCmd.Flags().BoolVar(&forceMultipart, "force-multipart", false, "Force to use multipart upload if possible")
-	RootCmd.AddCommand(uploadNewCmd)
+	uploadCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory or file in which contains file(s) to be uploaded")
+	uploadCmd.MarkFlagRequired("upload-path")
+	uploadCmd.Flags().BoolVar(&batch, "batch", false, "Upload in parallel")
+	uploadCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
+	uploadCmd.Flags().BoolVar(&includeSubDirName, "include-subdirname", false, "Include subdirectory names in file name")
+	uploadCmd.Flags().BoolVar(&forceMultipart, "force-multipart", false, "Force to use multipart upload if possible")
+	RootCmd.AddCommand(uploadCmd)
 }

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -133,6 +133,8 @@ func init() {
 		},
 	}
 
+	uploadCmd.Flags().StringVar(&profile, "profile", "", "Specify profile to use")
+	uploadCmd.MarkFlagRequired("profile")
 	uploadCmd.Flags().StringVar(&uploadPath, "upload-path", "", "The directory or file in which contains file(s) to be uploaded")
 	uploadCmd.MarkFlagRequired("upload-path")
 	uploadCmd.Flags().BoolVar(&batch, "batch", false, "Upload in parallel")


### PR DESCRIPTION
To fulfill https://ctds-planx.atlassian.net/browse/PXP-3431

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Make `manifest` flag required so the help menu is displayed in a consistent way across commands
- Make `profile` flag required for the following commands: `upload`, `upload-single`, `upload-multiple`, `download-single`, `download-multiple`, `configure` and `auth`


### Dependency updates


### Deployment changes

