### PR TITLE
Fix/absolute path

### DIFF
--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -69,6 +69,8 @@ func ParseFilePaths(filePath string) ([]string, error) {
 		return nil, err
 	}
 
+	filePaths = cleanupHiddenFiles(filePaths)
+
 	for _, filePath := range filePaths {
 		func() {
 			file, err := os.Open(filePath)
@@ -88,13 +90,15 @@ func ParseFilePaths(filePath string) ([]string, error) {
 					}
 					if !fileInfo.IsDir() && !isHidden {
 						filePaths = append(filePaths, path)
+					} else if isHidden {
+						log.Printf("File %s is a hidden file and will be skipped\n", path)
 					}
 					return nil
 				})
 			}
 		}()
 	}
-	log.Println("Finish parsing all file paths for \"" + filePath + "\"")
+	log.Println("Finish parsing all file paths for \"" + fullFilePath + "\"")
 	return filePaths, err
 }
 
@@ -118,4 +122,23 @@ func AskForConfirmation(s string) bool {
 			return false
 		}
 	}
+}
+
+func cleanupHiddenFiles(filePaths []string) []string {
+	i := 0
+	for _, filePath := range filePaths {
+		isHidden, err := IsHidden(filePath)
+		if err != nil {
+			log.Println("Error occurred when checking hidden files: " + err.Error())
+			continue
+		}
+
+		if isHidden {
+			log.Printf("File %s is a hidden file and will be skipped\n", filePath)
+			continue
+		}
+		filePaths[i] = filePath
+		i++
+	}
+	return filePaths[:i]
 }

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -81,6 +82,12 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject) {
 			} else {
 				log.Println(err.Error())
 			}
+		}
+
+		if ro.Filename == "" {
+			filePath, _ := commonUtils.GetAbsolutePath(ro.FilePath)
+			filename := filepath.Base(filePath)
+			updateRetryObject(ro, filePath, filename, ro.GUID, ro.RetryCount, true)
 		}
 
 		if ro.Multipart {

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -86,7 +86,7 @@ func init() {
 					if len(batchFURObjects) < workers {
 						batchFURObjects = append(batchFURObjects, furObject)
 					} else {
-						batchUpload(uploadPath, false, batchFURObjects, workers, respCh, errCh)
+						batchUpload(batchFURObjects, workers, respCh, errCh)
 						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
 						batchFURObjects = append(batchFURObjects, furObject)
 					}
@@ -94,7 +94,7 @@ func init() {
 					file, err := os.Open(furObject.FilePath)
 					if err != nil {
 						log.Println("File open error: " + err.Error())
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, 0, false, true)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						continue
 					}
@@ -103,7 +103,7 @@ func init() {
 					furObject, err := GenerateUploadRequest(furObject, file)
 					if err != nil {
 						file.Close()
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, 0, false, true)
+						logs.AddToFailedLogMap(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						log.Printf("Error occurred during request generation: %s", err.Error())
 						continue

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 
@@ -37,8 +37,9 @@ func init() {
 			if len(filePaths) == 1 {
 				filePath = filePaths[0]
 			}
+			filename := filepath.Base(filePath)
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {
-				logs.AddToFailedLogMap(filePath, "", 0, false, true)
+				logs.AddToFailedLogMap(filePath, filename, "", 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -48,7 +49,7 @@ func init() {
 
 			file, err := os.Open(filePath)
 			if err != nil {
-				logs.AddToFailedLogMap(filePath, "", 0, false, true)
+				logs.AddToFailedLogMap(filePath, filename, "", 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
@@ -57,12 +58,12 @@ func init() {
 			}
 			defer file.Close()
 
-			furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, Filename: path.Base(filePath), GUID: guid}
+			furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, Filename: filename, GUID: guid}
 
 			furObject, err = GenerateUploadRequest(furObject, file)
 			if err != nil {
 				file.Close()
-				logs.AddToFailedLogMap(furObject.FilePath, furObject.GUID, 0, false, true)
+				logs.AddToFailedLogMap(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
 				logs.WriteToFailedLog()
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/uc-cdis/gen3-client/gen3-client/commonUtils"
@@ -26,6 +27,7 @@ func init() {
 			"Or:\n./gen3-client upload --profile=<profile-name> --upload-path=<path-to-files/*/folder/*.bam>",
 		Run: func(cmd *cobra.Command, args []string) {
 			logs.InitScoreBoard(MaxRetryCount)
+			uploadPath, _ = commonUtils.GetAbsolutePath(uploadPath)
 			filePaths, err := commonUtils.ParseFilePaths(uploadPath)
 			if err != nil {
 				log.Fatalf("Error when parsing file paths: " + err.Error())
@@ -51,7 +53,7 @@ func init() {
 				for _, filePath := range singlepartFilePaths {
 					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("Process filename error: " + err.Error())
 						continue
 					}
@@ -80,20 +82,20 @@ func init() {
 				for _, filePath := range singlepartFilePaths {
 					file, err := os.Open(filePath)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("File open error: " + err.Error())
 						continue
 					}
 
 					fi, err := file.Stat()
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 						continue
 					}
 					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("Process filename error for file: " + err.Error())
 						continue
 					}
@@ -128,7 +130,7 @@ func init() {
 				for _, filePath := range multipartFilePaths {
 					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("Process filename error for file: " + err.Error())
 						continue
 					}

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -49,19 +49,19 @@ func init() {
 			if batch {
 				workers, respCh, errCh, batchFURObjects := initBatchUploadChannels(numParallel, len(singlepartFilePaths))
 				for _, filePath := range singlepartFilePaths {
-					fileinfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
+					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
 						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 						log.Println("Process filename error: " + err.Error())
 						continue
 					}
 					if len(batchFURObjects) < workers {
-						furObject := commonUtils.FileUploadRequestObject{FilePath: fileinfo.FilePath, Filename: fileinfo.Filename, GUID: ""}
+						furObject := commonUtils.FileUploadRequestObject{FilePath: fileInfo.FilePath, Filename: fileInfo.Filename, GUID: ""}
 						batchFURObjects = append(batchFURObjects, furObject)
 					} else {
 						batchUpload(batchFURObjects, workers, respCh, errCh)
 						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
-						furObject := commonUtils.FileUploadRequestObject{FilePath: fileinfo.FilePath, Filename: fileinfo.Filename, GUID: ""}
+						furObject := commonUtils.FileUploadRequestObject{FilePath: fileInfo.FilePath, Filename: fileInfo.Filename, GUID: ""}
 						batchFURObjects = append(batchFURObjects, furObject)
 					}
 				}
@@ -91,20 +91,20 @@ func init() {
 						log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 						continue
 					}
-					fileinfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
+					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
 						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 						log.Println("Process filename error for file: " + err.Error())
 						continue
 					}
 					// The following flow is for singlepart upload flow
-					respURL, guid, err := GeneratePresignedURL(fileinfo.Filename)
+					respURL, guid, err := GeneratePresignedURL(fileInfo.Filename)
 					if err != nil {
-						logs.AddToFailedLogMap(fileinfo.FilePath, fileinfo.Filename, guid, 0, false, true)
+						logs.AddToFailedLogMap(fileInfo.FilePath, fileInfo.Filename, guid, 0, false, true)
 						log.Println(err.Error())
 						continue
 					}
-					furObject := commonUtils.FileUploadRequestObject{FilePath: fileinfo.FilePath, Filename: fileinfo.Filename, GUID: guid, PresignedURL: respURL}
+					furObject := commonUtils.FileUploadRequestObject{FilePath: fileInfo.FilePath, Filename: fileInfo.Filename, GUID: guid, PresignedURL: respURL}
 					furObject, err = GenerateUploadRequest(furObject, file)
 					if err != nil {
 						file.Close()
@@ -126,13 +126,13 @@ func init() {
 			if len(multipartFilePaths) > 0 {
 				log.Println("Multipart uploading....")
 				for _, filePath := range multipartFilePaths {
-					fileinfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
+					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
 						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 						log.Println("Process filename error for file: " + err.Error())
 						continue
 					}
-					err = multipartUpload(fileinfo, 0)
+					err = multipartUpload(fileInfo, 0)
 					if err != nil {
 						log.Println(err.Error())
 					} else {

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/uc-cdis/gen3-client/gen3-client/commonUtils"
@@ -27,7 +26,6 @@ func init() {
 			"Or:\n./gen3-client upload --profile=<profile-name> --upload-path=<path-to-files/*/folder/*.bam>",
 		Run: func(cmd *cobra.Command, args []string) {
 			logs.InitScoreBoard(MaxRetryCount)
-			uploadPath = filepath.Clean(uploadPath)
 			filePaths, err := commonUtils.ParseFilePaths(uploadPath)
 			if err != nil {
 				log.Fatalf("Error when parsing file paths: " + err.Error())
@@ -51,17 +49,23 @@ func init() {
 			if batch {
 				workers, respCh, errCh, batchFURObjects := initBatchUploadChannels(numParallel, len(singlepartFilePaths))
 				for _, filePath := range singlepartFilePaths {
+					fileinfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
+					if err != nil {
+						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						log.Println("Process filename error: " + err.Error())
+						continue
+					}
 					if len(batchFURObjects) < workers {
-						furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, GUID: ""}
+						furObject := commonUtils.FileUploadRequestObject{FilePath: fileinfo.FilePath, Filename: fileinfo.Filename, GUID: ""}
 						batchFURObjects = append(batchFURObjects, furObject)
 					} else {
-						batchUpload(uploadPath, includeSubDirName, batchFURObjects, workers, respCh, errCh)
+						batchUpload(batchFURObjects, workers, respCh, errCh)
 						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
-						furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, GUID: ""}
+						furObject := commonUtils.FileUploadRequestObject{FilePath: fileinfo.FilePath, Filename: fileinfo.Filename, GUID: ""}
 						batchFURObjects = append(batchFURObjects, furObject)
 					}
 				}
-				batchUpload(uploadPath, includeSubDirName, batchFURObjects, workers, respCh, errCh)
+				batchUpload(batchFURObjects, workers, respCh, errCh)
 
 				if len(errCh) > 0 {
 					close(errCh)
@@ -76,25 +80,31 @@ func init() {
 				for _, filePath := range singlepartFilePaths {
 					file, err := os.Open(filePath)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 						log.Println("File open error: " + err.Error())
 						continue
 					}
 
 					fi, err := file.Stat()
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, "", 0, false, true)
+						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
 						log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 						continue
 					}
-					// The following flow is for singlepart upload flow
-					respURL, guid, filename, err := GeneratePresignedURL(uploadPath, filePath, includeSubDirName)
+					fileinfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, guid, 0, false, true)
+						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						log.Println("Process filename error for file: " + err.Error())
+						continue
+					}
+					// The following flow is for singlepart upload flow
+					respURL, guid, err := GeneratePresignedURL(fileinfo.Filename)
+					if err != nil {
+						logs.AddToFailedLogMap(fileinfo.FilePath, fileinfo.Filename, guid, 0, false, true)
 						log.Println(err.Error())
 						continue
 					}
-					furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, Filename: filename, GUID: guid, PresignedURL: respURL}
+					furObject := commonUtils.FileUploadRequestObject{FilePath: fileinfo.FilePath, Filename: fileinfo.Filename, GUID: guid, PresignedURL: respURL}
 					furObject, err = GenerateUploadRequest(furObject, file)
 					if err != nil {
 						file.Close()
@@ -116,7 +126,13 @@ func init() {
 			if len(multipartFilePaths) > 0 {
 				log.Println("Multipart uploading....")
 				for _, filePath := range multipartFilePaths {
-					err = multipartUpload(uploadPath, filePath, includeSubDirName, 0)
+					fileinfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
+					if err != nil {
+						logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+						log.Println("Process filename error for file: " + err.Error())
+						continue
+					}
+					err = multipartUpload(fileinfo, 0)
 					if err != nil {
 						log.Println(err.Error())
 					} else {
@@ -126,7 +142,7 @@ func init() {
 			}
 
 			if !logs.IsFailedLogMapEmpty() {
-				retryUpload(logs.GetFailedLogMap(), uploadPath, includeSubDirName)
+				retryUpload(logs.GetFailedLogMap())
 			}
 			logs.CloseAll()
 			logs.PrintScoreBoard()

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -373,7 +372,7 @@ func validateObject(objects []ManifestObject, uploadPath string) []commonUtils.F
 			continue
 		}
 
-		furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, Filename: path.Base(filePath), GUID: guid}
+		furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, Filename: filepath.Base(filePath), GUID: guid}
 		furObjects = append(furObjects, furObject)
 	}
 	return furObjects

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -301,7 +301,7 @@ func validateFilePath(filePaths []string, forceMultipart bool) ([]string, []stri
 				log.Println("File \"" + filePath + "\" has been found in local submission history and has be skipped for preventing duplicated submissions.")
 				return
 			}
-			logs.AddToFailedLogMap(filePath, "", "", 0, false, true)
+			logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
 
 			if fi.Size() > MultipartFileSizeLimit {
 				log.Printf("The file size of %s has exceeded the limit allowed and cannot be uploaded. The maximum allowed file size is %s\n", fi.Name(), FormatSize(MultipartFileSizeLimit))
@@ -325,12 +325,12 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool)
 		uploadPath, err = commonUtils.GetAbsolutePath(uploadPath)
 		presentDirname := strings.TrimSuffix(uploadPath, commonUtils.PathSeparator+"*")
 		subFilename := strings.TrimPrefix(filePath, presentDirname)
-		dir, _ := filepath.Split(subFilename)
+		dir, file := filepath.Split(subFilename)
 		if dir != "" && dir != commonUtils.PathSeparator {
 			filename = strings.TrimPrefix(subFilename, commonUtils.PathSeparator)
 			filename = strings.Replace(filename, commonUtils.PathSeparator, ".", -1)
 		} else {
-			err = errors.New("Include subdirectory names will only works if the file is under at least one subdirectory")
+			filename = file
 		}
 	}
 	return FileInfo{filePath, filename}, err

--- a/gen3-client/logs/failed.go
+++ b/gen3-client/logs/failed.go
@@ -75,10 +75,10 @@ func GetFailedLogMap() map[string]commonUtils.RetryObject {
 	return failedLogFileMap
 }
 
-func AddToFailedLogMap(filePath string, guid string, retryCount int, isMultipart bool, isMuted bool) {
+func AddToFailedLogMap(filePath string, filename string, guid string, retryCount int, isMultipart bool, isMuted bool) {
 	failedLogLock.Lock()
 	defer failedLogLock.Unlock()
-	failedLogFileMap[filePath] = commonUtils.RetryObject{FilePath: filePath, GUID: guid, RetryCount: retryCount, Multipart: isMultipart}
+	failedLogFileMap[filePath] = commonUtils.RetryObject{FilePath: filePath, Filename: filename, GUID: guid, RetryCount: retryCount, Multipart: isMultipart}
 	if !isMuted {
 		log.Printf("Failed file entry added for %s\n", filePath)
 	}


### PR DESCRIPTION
To fulfill https://ctds-planx.atlassian.net/browse/PXP-3431

### New Features


### Breaking Changes


### Bug Fixes
- Clean up hidden files in current root dir


### Improvements
- Use absolute path in history (succeeded/failed) logs to prevent duplicated uploads
- Simplified `retry-upload` command by removing `upload-path` and `include-subdirname` as available options
- Save `filename` in failed logs

### Dependency updates


### Deployment changes

