### PR TITLE
Feat/rework download

### DIFF
--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -3,6 +3,7 @@ package commonUtils
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -28,6 +29,20 @@ type FileUploadRequestObject struct {
 	PresignedURL string
 	Request      *http.Request
 	Bar          *pb.ProgressBar
+}
+
+// FileDownloadResponseObject defines a object for file download
+type FileDownloadResponseObject struct {
+	DownloadPath string
+	Filename     string
+	GUID         string
+	URL          string
+	Range        int64
+	Overwrite    bool
+	Skip         bool
+	Error        bool
+	Response     *http.Response
+	Writer       io.Writer
 }
 
 // RetryObject defines a object for retry upload

--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -40,7 +40,6 @@ type FileDownloadResponseObject struct {
 	Range        int64
 	Overwrite    bool
 	Skip         bool
-	Error        bool
 	Response     *http.Response
 	Writer       io.Writer
 }

--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -15,6 +15,30 @@ import (
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
+// IndexdIndexEndpoint is the endpoint postfix for INDEXD index
+const IndexdIndexEndpoint = "/index/index"
+
+// FenceUserEndpoint is the endpoint postfix for FENCE user
+const FenceUserEndpoint = "/user/user"
+
+// FenceDataEndpoint is the endpoint postfix for FENCE data
+const FenceDataEndpoint = "/user/data"
+
+// FenceDataUploadEndpoint is the endpoint postfix for FENCE data upload
+const FenceDataUploadEndpoint = FenceDataEndpoint + "/upload"
+
+// FenceDataDownloadEndpoint is the endpoint postfix for FENCE data download
+const FenceDataDownloadEndpoint = FenceDataEndpoint + "/download"
+
+// FenceDataMultipartInitEndpoint is the endpoint postfix for FENCE multipart init
+const FenceDataMultipartInitEndpoint = FenceDataEndpoint + "/multipart/init"
+
+// FenceDataMultipartUploadEndpoint is the endpoint postfix for FENCE multipart upload
+const FenceDataMultipartUploadEndpoint = FenceDataEndpoint + "/multipart/upload"
+
+// FenceDataMultipartCompleteEndpoint is the endpoint postfix for FENCE multipart complete
+const FenceDataMultipartCompleteEndpoint = FenceDataEndpoint + "/multipart/complete"
+
 // PathSeparator is os dependent path separator char
 const PathSeparator = string(os.PathSeparator)
 

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -138,17 +138,18 @@ func batchDownload(batchFDRSlice []commonUtils.FileDownloadResponseObject, proto
 			continue
 		}
 
-		fileFlag := os.O_CREATE | os.O_WRONLY
+		fileFlag := os.O_CREATE | os.O_RDWR
 		if fdrObject.Range != 0 {
-			fileFlag = os.O_APPEND | os.O_WRONLY
+			fileFlag = os.O_APPEND | os.O_RDWR
 		} else if fdrObject.Overwrite {
-			fileFlag = os.O_TRUNC | os.O_WRONLY
+			fileFlag = os.O_TRUNC | os.O_RDWR
 		}
 
-		if fileFlag == os.O_CREATE|os.O_WRONLY {
-			log.Println("")
+		subDir := filepath.Dir(fdrObject.Filename)
+		if subDir != "." && subDir != "/" {
+			os.MkdirAll(fdrObject.DownloadPath+subDir, 0766)
 		}
-		file, err := os.OpenFile(fdrObject.DownloadPath+fdrObject.Filename, fileFlag, 0644)
+		file, err := os.OpenFile(fdrObject.DownloadPath+fdrObject.Filename, fileFlag, 0766)
 		if err != nil {
 			errCh <- errors.New("Error occurred during opening local file: " + err.Error())
 			continue

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -130,7 +130,7 @@ func validateLocalFileStat(downloadPath string, filename string, filesize int64,
 
 func batchDownload(batchFDRSlice []commonUtils.FileDownloadResponseObject, protocolText string, workers int, errCh chan error) int {
 	bars := make([]*pb.ProgressBar, 0)
-	fdrs := make([]*commonUtils.FileDownloadResponseObject, 0)
+	fdrs := make([]commonUtils.FileDownloadResponseObject, 0)
 	for _, fdrObject := range batchFDRSlice {
 		err := GetDownloadResponse(&fdrObject, protocolText)
 		if err != nil {
@@ -160,10 +160,10 @@ func batchDownload(batchFDRSlice []commonUtils.FileDownloadResponseObject, proto
 		writer := io.MultiWriter(file, bar)
 		bars = append(bars, bar)
 		fdrObject.Writer = writer
-		fdrs = append(fdrs, &fdrObject)
+		fdrs = append(fdrs, fdrObject)
 	}
 
-	fdrCh := make(chan *commonUtils.FileDownloadResponseObject, len(fdrs))
+	fdrCh := make(chan commonUtils.FileDownloadResponseObject, len(fdrs))
 	pool, err := pb.StartPool(bars...)
 	if err != nil {
 		errCh <- errors.New("Error occurred during starting progress bar pool: " + err.Error())

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -272,7 +272,7 @@ func downloadFile(guids []string, downloadPath string, filenameFormat string, re
 	batchFDRSlice := make([]commonUtils.FileDownloadResponseObject, 0)
 	for i, fdrObject := range fdrObjects {
 		if fdrObject.Skip {
-			log.Printf("File \"%s\" (GUID: %s) has been skipped\n", fdrObject.Filename, fdrObject.GUID)
+			log.Printf("File \"%s\" (GUID: %s) has been skipped because there is a complete local copy\n", fdrObject.Filename, fdrObject.GUID)
 			skippedFiles = append(skippedFiles, RenamedOrSkippedFileInfo{GUID: fdrObject.GUID, OldFilename: fdrObject.Filename})
 			continue
 		}

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -31,7 +31,7 @@ func askGen3ForFileInfo(guid string, protocolText string, downloadPath string, f
 	function.Request = request
 
 	// ask INDEXD first
-	endPointPostfix := "/index/index/" + guid
+	endPointPostfix := commonUtils.IndexdIndexEndpoint + "/" + guid
 	indexdMsg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
 	if err != nil {
 		log.Println("Error occurred when querying filename from IndexD: " + err.Error())
@@ -50,7 +50,7 @@ func askGen3ForFileInfo(guid string, protocolText string, downloadPath string, f
 	if actualFilename == "" {
 		// INDEXD record is not reliable, try asking FENCE and guessing filename from returned URL
 		// If guessed filename is "", then use GUID instead
-		endPointPostfix := "/user/data/download/" + guid + protocolText
+		endPointPostfix := commonUtils.FenceDataDownloadEndpoint + "/" + guid + protocolText
 		fenceMsg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
 
 		if err != nil || fenceMsg.URL == "" {
@@ -114,13 +114,13 @@ func validateFilenameFormat(downloadPath string, filenameFormat string, rename b
 		log.Fatalln("Invalid option found! Option \"filename-format\" can either be \"original\", \"guid\" or \"combined\" only")
 	}
 	if filenameFormat == "guid" || filenameFormat == "combined" {
-		fmt.Printf("WARNING: in \"guid\" or \"combined\" mode, duplicated files under \"%s\" may be overwritten\n", downloadPath)
+		fmt.Printf("WARNING: in \"guid\" or \"combined\" mode, duplicated files under \"%s\" will be overwritten\n", downloadPath)
 		if !noPrompt && !commonUtils.AskForConfirmation("Proceed?") {
 			log.Println("Aborted by user")
 			os.Exit(0)
 		}
 	} else if !rename {
-		fmt.Printf("WARNING: flag \"rename\" was set to false in \"original\" mode, duplicated files under \"%s\" may be overwritten\n", downloadPath)
+		fmt.Printf("WARNING: flag \"rename\" was set to false in \"original\" mode, duplicated files under \"%s\" will be overwritten\n", downloadPath)
 		if !noPrompt && !commonUtils.AskForConfirmation("Proceed?") {
 			log.Println("Aborted by user")
 			os.Exit(0)
@@ -196,7 +196,7 @@ func batchDownload(batchFDRSlice []commonUtils.FileDownloadResponseObject, proto
 	fdrCh := make(chan commonUtils.FileDownloadResponseObject, len(fdrs))
 	pool, err := pb.StartPool(bars...)
 	if err != nil {
-		errCh <- errors.New("Error occurred during starting progress bar pool: " + err.Error())
+		errCh <- errors.New("Error occurred during initializing progress bars: " + err.Error())
 		return 0
 	}
 

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -147,9 +147,9 @@ func batchDownload(batchFDRSlice []commonUtils.FileDownloadResponseObject, proto
 
 		subDir := filepath.Dir(fdrObject.Filename)
 		if subDir != "." && subDir != "/" {
-			os.MkdirAll(fdrObject.DownloadPath+subDir, 0766)
+			os.MkdirAll(fdrObject.DownloadPath+subDir, 0666)
 		}
-		file, err := os.OpenFile(fdrObject.DownloadPath+fdrObject.Filename, fileFlag, 0766)
+		file, err := os.OpenFile(fdrObject.DownloadPath+fdrObject.Filename, fileFlag, 0666)
 		if err != nil {
 			errCh <- errors.New("Error occurred during opening local file: " + err.Error())
 			continue

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -294,13 +294,13 @@ func downloadFile(guids []string, downloadPath string, filenameFormat string, re
 	if len(renamedFiles) > 0 {
 		fmt.Printf("\n%d files have been renamed as the following:\n", len(renamedFiles))
 		for _, rfi := range renamedFiles {
-			fmt.Printf("File \"%s\" (GUID %s) has been renamed as: %s\n", rfi.OldFilename, rfi.GUID, rfi.NewFilename)
+			fmt.Printf("File \"%s\" (GUID: %s) has been renamed as: %s\n", rfi.OldFilename, rfi.GUID, rfi.NewFilename)
 		}
 	}
 	if len(skippedFiles) > 0 {
 		fmt.Printf("\n%d files have been skipped:\n", len(skippedFiles))
 		for _, sfi := range skippedFiles {
-			fmt.Printf("File \"%s\" (GUID %s) has been skipped\n", sfi.OldFilename, sfi.GUID)
+			fmt.Printf("File \"%s\" (GUID: %s) has been skipped\n", sfi.OldFilename, sfi.GUID)
 		}
 	}
 	if len(errCh) > 0 {

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -272,6 +272,7 @@ func downloadFile(guids []string, downloadPath string, filenameFormat string, re
 	batchFDRSlice := make([]commonUtils.FileDownloadResponseObject, 0)
 	for i, fdrObject := range fdrObjects {
 		if fdrObject.Skip {
+			log.Printf("File \"%s\" (GUID: %s) has been skipped\n", fdrObject.Filename, fdrObject.GUID)
 			skippedFiles = append(skippedFiles, RenamedOrSkippedFileInfo{GUID: fdrObject.GUID, OldFilename: fdrObject.Filename})
 			continue
 		}
@@ -288,22 +289,16 @@ func downloadFile(guids []string, downloadPath string, filenameFormat string, re
 		}
 	}
 
-	fmt.Printf("%d files downloaded.\n", totalCompeleted)
+	log.Printf("%d files downloaded.\n", totalCompeleted)
 
 	if len(renamedFiles) > 0 {
-		fmt.Printf("\n%d files have been renamed as the following:\n", len(renamedFiles))
-		for _, rfi := range renamedFiles {
-			fmt.Printf("File \"%s\" (GUID: %s) has been renamed as: %s\n", rfi.OldFilename, rfi.GUID, rfi.NewFilename)
-		}
+		log.Printf("\n%d files have been renamed as the following:\n", len(renamedFiles))
 	}
 	if len(skippedFiles) > 0 {
-		fmt.Printf("\n%d files have been skipped:\n", len(skippedFiles))
-		for _, sfi := range skippedFiles {
-			fmt.Printf("File \"%s\" (GUID: %s) has been skipped\n", sfi.OldFilename, sfi.GUID)
-		}
+		log.Printf("\n%d files have been skipped\n", len(skippedFiles))
 	}
 	if len(errCh) > 0 {
-		fmt.Printf("\n%d files have errorred during downloading\n", len(errCh))
+		log.Printf("\n%d files have errorred during downloading\n", len(errCh))
 	}
 }
 

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -180,7 +180,6 @@ func downloadFile(guids []string, downloadPath string, filenameFormat string, ov
 			log.Printf("Error in getting download URL for object %s\n", guid)
 		} else {
 			filename, _ := askIndexDForFileInfo(guid, downloadPath, filenameFormat, overwrite, &renamedFiles)
-			fmt.Println("WARNING: cannot parse URL to get actually filename, will use GUID as its filename by default.")
 			req, _ := grab.NewRequest(downloadPath+filename, msg.URL)
 			// NoResume specifies that a partially completed download will be restarted without attempting to resume any existing file
 			req.NoResume = true

--- a/gen3-client/g3cmd/download-single.go
+++ b/gen3-client/g3cmd/download-single.go
@@ -1,11 +1,7 @@
 package g3cmd
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
-	"github.com/uc-cdis/gen3-client/gen3-client/commonUtils"
-	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
 )
 
 func init() {
@@ -13,8 +9,9 @@ func init() {
 	var downloadPath string
 	var protocol string
 	var filenameFormat string
-	var overwrite bool
+	var rename bool
 	var noPrompt bool
+	var skipCompleted bool
 
 	var downloadSingleCmd = &cobra.Command{
 		Use:     "download-single",
@@ -22,24 +19,9 @@ func init() {
 		Long:    `Gets a presigned URL for a file from a GUID and then downloads the specified file.`,
 		Example: `./gen3-client download-single --profile=<profile-name> --guid=206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc`,
 		Run: func(cmd *cobra.Command, args []string) {
-
-			request := new(jwt.Request)
-			configure := new(jwt.Configure)
-			function := new(jwt.Functions)
-
-			function.Config = configure
-			function.Request = request
-
-			downloadPath = commonUtils.ParseRootPath(downloadPath)
-			if !strings.HasSuffix(downloadPath, "/") {
-				downloadPath += "/"
-			}
-			filenameFormat = strings.ToLower(strings.TrimSpace(filenameFormat))
-			validateFilenameFormat(downloadPath, filenameFormat, overwrite, noPrompt)
-
 			guids := make([]string, 0)
 			guids = append(guids, guid)
-			downloadFile(guids, downloadPath, filenameFormat, overwrite, protocol, 1, false)
+			downloadFile(guids, downloadPath, filenameFormat, rename, noPrompt, protocol, 1, skipCompleted)
 		},
 	}
 
@@ -49,8 +31,9 @@ func init() {
 	downloadSingleCmd.MarkFlagRequired("guid")
 	downloadSingleCmd.Flags().StringVar(&downloadPath, "download-path", ".", "The directory in which to store the downloaded files")
 	downloadSingleCmd.Flags().StringVar(&filenameFormat, "filename-format", "original", "The format of filename to be used, including \"original\", \"guid\" and \"combined\"")
-	downloadSingleCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Only useful when \"--filename-format=original\", will overwrite any duplicates in \"download-path\" if set to true, will rename file by appending a counter value to its filename otherwise (default: false)")
-	downloadSingleCmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "If set to true, will not display user prompt message for confirmation (default: false)")
-	downloadSingleCmd.Flags().StringVar(&protocol, "protocol", "", "Specify the preferred protocol with --protocol=gs (default: \"\")")
+	downloadSingleCmd.Flags().BoolVar(&rename, "rename", false, "Only useful when \"--filename-format=original\", will rename file by appending a counter value to its filename if set to true, otherwise the same filename will be used")
+	downloadSingleCmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "If set to true, will not display user prompt message for confirmation")
+	downloadSingleCmd.Flags().StringVar(&protocol, "protocol", "", "Specify the preferred protocol with --protocol=gs")
+	downloadSingleCmd.Flags().BoolVar(&skipCompleted, "skip-completed", false, "If set to true, will check for filename and size before download and skip any files in \"download-path\" that matches both")
 	RootCmd.AddCommand(downloadSingleCmd)
 }

--- a/gen3-client/g3cmd/download-single.go
+++ b/gen3-client/g3cmd/download-single.go
@@ -39,7 +39,7 @@ func init() {
 
 			guids := make([]string, 0)
 			guids = append(guids, guid)
-			downloadFile(guids, downloadPath, filenameFormat, overwrite, protocol, 1)
+			downloadFile(guids, downloadPath, filenameFormat, overwrite, protocol, 1, false)
 		},
 	}
 

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -86,7 +86,7 @@ func init() {
 						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
 						batchFURObjects = append(batchFURObjects, furObject)
 					}
-					if i == len(furObjects)-1 { // upload reminders
+					if i == len(furObjects)-1 { // upload remainders
 						batchUpload(batchFURObjects, workers, respCh, errCh)
 					}
 				} else {

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -77,7 +77,7 @@ func init() {
 				workers, respCh, errCh, batchFURObjects = initBatchUploadChannels(numParallel, len(objects))
 			}
 
-			for _, furObject := range furObjects {
+			for i, furObject := range furObjects {
 				if batch {
 					if len(batchFURObjects) < workers {
 						batchFURObjects = append(batchFURObjects, furObject)
@@ -85,6 +85,9 @@ func init() {
 						batchUpload(batchFURObjects, workers, respCh, errCh)
 						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
 						batchFURObjects = append(batchFURObjects, furObject)
+					}
+					if i == len(furObjects)-1 { // upload reminders
+						batchUpload(batchFURObjects, workers, respCh, errCh)
 					}
 				} else {
 					file, err := os.Open(furObject.FilePath)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -172,7 +172,7 @@ func CompleteMultipartUpload(key string, uploadID string, parts []MultipartPartO
 	return nil
 }
 
-// GeneratePresignedURL helps sending requests to FENCE and parsing the response
+// GeneratePresignedURL helps sending requests to FENCE and parsing the response in order to get presigned URL for the new upload flow
 func GeneratePresignedURL(filename string) (string, string, error) {
 	request := new(jwt.Request)
 	configure := new(jwt.Configure)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -223,7 +223,7 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 		fdrObject.Error = true
 		return errors.New(errorMsg)
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 206 {
 		errorMsg := "Got a non-200 response when doing GET req for URL " + fdrObject.URL
 		errorMsg += "\n HTTP status code for response: " + strconv.Itoa(resp.StatusCode) + "\n"
 		fdrObject.Error = true

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -186,7 +186,7 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 	if err != nil || msg.URL == "" {
 		errorMsg := "Error occurred when getting download URL for object " + fdrObject.GUID
 		if err != nil {
-			errorMsg += "\n Details of error: " + err.Error() + "\n"
+			errorMsg += "\n Details of error: " + err.Error()
 		}
 		return errors.New(errorMsg)
 	}
@@ -196,7 +196,7 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 		resp, err := http.Head(fdrObject.URL)
 		if err != nil {
 			errorMsg := "Error occurred when sending HEAD req to URL " + fdrObject.URL
-			errorMsg += "\n Details of error: " + err.Error() + "\n"
+			errorMsg += "\n Details of error: " + err.Error()
 			return errors.New(errorMsg)
 		}
 		if resp.Header.Get("Accept-Ranges") != "bytes" { // server does not support range, download without range header
@@ -206,7 +206,7 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 	req, err := http.NewRequest(http.MethodGet, fdrObject.URL, nil)
 	if err != nil {
 		errorMsg := "Error occurred when creating GET req for URL " + fdrObject.URL
-		errorMsg += "\n Details of error: " + err.Error() + "\n"
+		errorMsg += "\n Details of error: " + err.Error()
 		return errors.New(errorMsg)
 	}
 	if fdrObject.Range != 0 {
@@ -216,12 +216,12 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 	resp, err := client.Do(req)
 	if err != nil {
 		errorMsg := "Error occurred when doing GET req for URL " + fdrObject.URL
-		errorMsg += "\n Details of error: " + err.Error() + "\n"
+		errorMsg += "\n Details of error: " + err.Error()
 		return errors.New(errorMsg)
 	}
 	if resp.StatusCode != 200 && resp.StatusCode != 206 {
-		errorMsg := "Got a non-200 response when doing GET req for URL " + fdrObject.URL
-		errorMsg += "\n HTTP status code for response: " + strconv.Itoa(resp.StatusCode) + "\n"
+		errorMsg := "Got a non-200 or non-206 response when doing GET req for URL " + fdrObject.URL
+		errorMsg += "\n HTTP status code for response: " + strconv.Itoa(resp.StatusCode)
 		return errors.New(errorMsg)
 	}
 	fdrObject.Response = resp

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -109,11 +109,10 @@ func InitMultipartUpload(filename string) (string, string, error) {
 	function.Config = configure
 	function.Request = request
 
-	endPointPostfix := "/user/data/multipart/init"
 	multipartInitObject := InitRequestObject{Filename: filename}
 	objectBytes, err := json.Marshal(multipartInitObject)
 
-	msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "application/json", objectBytes)
+	msg, err := function.DoRequestWithSignedHeader(profile, "", commonUtils.FenceDataMultipartInitEndpoint, "application/json", objectBytes)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -136,11 +135,10 @@ func GenerateMultipartPresignedURL(key string, uploadID string, partNumber int) 
 	function.Config = configure
 	function.Request = request
 
-	endPointPostfix := "/user/data/multipart/upload"
 	multipartUploadObject := MultipartUploadRequestObject{Key: key, UploadID: uploadID, PartNumber: partNumber}
 	objectBytes, err := json.Marshal(multipartUploadObject)
 
-	msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "application/json", objectBytes)
+	msg, err := function.DoRequestWithSignedHeader(profile, "", commonUtils.FenceDataMultipartUploadEndpoint, "application/json", objectBytes)
 
 	if err != nil {
 		return "", errors.New("Error has occurred during multipart upload presigned url generation, detailed error message: " + err.Error())
@@ -160,11 +158,10 @@ func CompleteMultipartUpload(key string, uploadID string, parts []MultipartPartO
 	function.Config = configure
 	function.Request = request
 
-	endPointPostfix := "/user/data/multipart/complete"
 	multipartCompleteObject := MultipartCompleteRequestObject{Key: key, UploadID: uploadID, Parts: parts}
 	objectBytes, err := json.Marshal(multipartCompleteObject)
 
-	_, err = function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "application/json", objectBytes)
+	_, err = function.DoRequestWithSignedHeader(profile, "", commonUtils.FenceDataMultipartCompleteEndpoint, "application/json", objectBytes)
 
 	if err != nil {
 		return errors.New("Error has occurred during completing multipart upload, detailed error message: " + err.Error())
@@ -180,7 +177,7 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 
 	function.Config = configure
 	function.Request = request
-	endPointPostfix := "/user/data/download/" + fdrObject.GUID + protocolText
+	endPointPostfix := commonUtils.FenceDataDownloadEndpoint + "/" + fdrObject.GUID + protocolText
 	msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
 
 	if err != nil || msg.URL == "" {
@@ -237,11 +234,10 @@ func GeneratePresignedURL(filename string) (string, string, error) {
 	function.Config = configure
 	function.Request = request
 
-	endPointPostfix := "/user/data/upload"
 	purObject := InitRequestObject{Filename: filename}
 	objectBytes, err := json.Marshal(purObject)
 
-	msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "application/json", objectBytes)
+	msg, err := function.DoRequestWithSignedHeader(profile, "", commonUtils.FenceDataUploadEndpoint, "application/json", objectBytes)
 
 	if err != nil {
 		return "", "", errors.New("You don't have permission to upload data, detailed error message: " + err.Error())
@@ -262,7 +258,7 @@ func GenerateUploadRequest(furObject commonUtils.FileUploadRequestObject, file *
 	function.Request = request
 
 	if furObject.PresignedURL == "" {
-		endPointPostfix := "/user/data/upload/" + furObject.GUID
+		endPointPostfix := commonUtils.FenceDataUploadEndpoint + "/" + furObject.GUID
 		msg, err := function.DoRequestWithSignedHeader(profile, "", endPointPostfix, "", nil)
 		if err != nil && !strings.Contains(err.Error(), "No GUID found") {
 			return furObject, errors.New("Upload error: " + err.Error())

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -188,7 +188,6 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 		if err != nil {
 			errorMsg += "\n Details of error: " + err.Error() + "\n"
 		}
-		fdrObject.Error = true
 		return errors.New(errorMsg)
 	}
 
@@ -198,7 +197,6 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 		if err != nil {
 			errorMsg := "Error occurred when sending HEAD req to URL " + fdrObject.URL
 			errorMsg += "\n Details of error: " + err.Error() + "\n"
-			fdrObject.Error = true
 			return errors.New(errorMsg)
 		}
 		if resp.Header.Get("Accept-Ranges") != "bytes" { // server does not support range, download without range header
@@ -209,7 +207,6 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 	if err != nil {
 		errorMsg := "Error occurred when creating GET req for URL " + fdrObject.URL
 		errorMsg += "\n Details of error: " + err.Error() + "\n"
-		fdrObject.Error = true
 		return errors.New(errorMsg)
 	}
 	if fdrObject.Range != 0 {
@@ -220,13 +217,11 @@ func GetDownloadResponse(fdrObject *commonUtils.FileDownloadResponseObject, prot
 	if err != nil {
 		errorMsg := "Error occurred when doing GET req for URL " + fdrObject.URL
 		errorMsg += "\n Details of error: " + err.Error() + "\n"
-		fdrObject.Error = true
 		return errors.New(errorMsg)
 	}
 	if resp.StatusCode != 200 && resp.StatusCode != 206 {
 		errorMsg := "Got a non-200 response when doing GET req for URL " + fdrObject.URL
 		errorMsg += "\n HTTP status code for response: " + strconv.Itoa(resp.StatusCode) + "\n"
-		fdrObject.Error = true
 		return errors.New(errorMsg)
 	}
 	fdrObject.Response = resp

--- a/gen3-client/jwt/configure.go
+++ b/gen3-client/jwt/configure.go
@@ -37,17 +37,9 @@ type ConfigureInterface interface {
 
 func (conf *Configure) ReadFile(filePath string, fileType string) string {
 	//Look in config file
-	fullFilePaths, err := commonUtils.ParseFilePaths(filePath)
-	if len(fullFilePaths) > 1 {
-		log.Println("More than 1 file location has been found. Do not use \"*\" in file path or provide a folder as file path.")
-		return ""
-	}
+	fullFilePath, err := commonUtils.GetAbsolutePath(filePath)
 	if err != nil {
-		panic(err)
-	}
-	var fullFilePath = filePath
-	if len(fullFilePaths) == 1 {
-		fullFilePath = fullFilePaths[0]
+		log.Println("error occurred when parsing config file path: " + err.Error())
 	}
 	if _, err := os.Stat(fullFilePath); err != nil {
 		log.Println("File specified at " + fullFilePath + " not found")

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -216,9 +216,7 @@ func (f *Functions) CheckPrivileges(profile string, configFileType string) (stri
 	var err error
 	var data map[string]interface{}
 
-	endPointPostfix := "/user/user" // Information about current user
-
-	host, resp, err := f.GetResponse(profile, configFileType, endPointPostfix, "GET", "", nil)
+	host, resp, err := f.GetResponse(profile, configFileType, commonUtils.FenceUserEndpoint, "GET", "", nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -242,7 +240,7 @@ func (f *Functions) DeleteRecord(profile string, configFileType string, guid str
 	var err error
 	var msg string
 
-	endPointPostfix := "/user/data/" + guid
+	endPointPostfix := commonUtils.FenceDataEndpoint + "/" + guid
 
 	_, resp, err := f.GetResponse(profile, configFileType, endPointPostfix, "DELETE", "", nil)
 

--- a/gen3-client/jwt/utils.go
+++ b/gen3-client/jwt/utils.go
@@ -19,6 +19,8 @@ type JsonMessage struct {
 	GUID         string `json:"guid"`
 	UploadID     string `json:"uploadId"`
 	PresignedURL string `json:"presigned_url"`
+	FileName     string `json:"file_name"`
+	Size         int64  `json:"size"`
 }
 
 type DoRequest func(*http.Response) *http.Response


### PR DESCRIPTION
This PR fulfills both https://ctds-planx.atlassian.net/browse/PXP-3961 and https://ctds-planx.atlassian.net/browse/PXP-3580

https://ctds-planx.atlassian.net/browse/PXP-3580 asks for ability for user to restart download using `gen3-client`. In order to do that, we refined the logic for both `download-single` and `download-multiple` commands by replacing the `overwrite` option flag with `rename` and `skip-completed` flags.

The `rename` flag is similar as the previous `overwrite` flag. It determines whether files will be renamed automatically and will only works if `filename-format` flag is `original`. Auto-renaming **will NOT work**  if `filename-format` flag is either `guid` or `combined`.

The `skip-completed` flag determines whether to check if local duplicated files should be skipped, resumed or downloaded from beginning. If its value is `false` then no checking will be performed. All files will be downloaded from beginning. If its value is `true` then the application uses the following logic to determine what to do with the download. 
![Blank Diagram](https://user-images.githubusercontent.com/2475897/63727624-85c36b80-c826-11e9-8ed9-870d9db8fd87.png)



### New Features
- Option flag `rename` has been added for both `download-single` and `download-multiple` commands.  The default value of this flag is `false`.
- Option flag `skip-completed` has been added for both `download-single` and `download-multiple` commands. The default value of this flag is `false`.
- If set `skip-completed` to `true`, files will be: 1. skipped from downloading if there is a completed local duplicate, or 2. resumed if there is an incomplete local duplicate, or 3. downloaded as a whole if there is no local duplicate.


### Breaking Changes
- Option flag `overwrite` has been removed for both `download-single` and `download-multiple` commands. Its functionality has been replaced by the combination of `rename` and `skip-completed` flags


### Bug Fixes
- For `download-multiple` command, now it will generate presigned URLs in small batches to avoid presigned URL expirations


### Improvements
- Both `download-single` and `download-multiple` commands now have progress bar tracking, UX is similar to those `upload` related commands
- Better filename guessing logic for `download-single` and `download-multiple` command


### Dependency updates


### Deployment changes

