### PR TITLE
PXP-4520 Fix/retry

### DIFF
--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -58,7 +58,7 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject) {
 	retryObjCh := make(chan commonUtils.RetryObject, len(failedLogMap))
 	for _, v := range failedLogMap {
 		if logs.ExistsInSucceededLog(v.FilePath) {
-			log.Println("File \"" + v.FilePath + "\" has been found in local submission history and has be skipped for preventing duplicated submissions.")
+			log.Println("File \"" + v.FilePath + "\" has been found in local submission history and has been skipped for preventing duplicated submissions.")
 			continue
 		}
 		retryObjCh <- v

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -22,7 +22,7 @@ func updateRetryObject(ro commonUtils.RetryObject, filePath string, filename str
 
 func handleFailedRetry(ro commonUtils.RetryObject, retryObjCh chan commonUtils.RetryObject, err error, isMuted bool) {
 	ro.RetryCount++
-	logs.AddToFailedLogMap(ro.FilePath, ro.Filename, ro.GUID, ro.RetryCount, ro.Multipart, isMuted)
+	logs.AddToFailedLog(ro.FilePath, ro.Filename, ro.GUID, ro.RetryCount, ro.Multipart, isMuted)
 	if err != nil {
 		log.Println(err.Error())
 	}
@@ -143,7 +143,7 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject) {
 				file.Close()
 				continue
 			}
-			logs.DeleteFromFailedLogMap(furObject.FilePath, true)
+			logs.DeleteFromFailedLog(furObject.FilePath, true)
 			logs.IncrementScore(ro.RetryCount)
 			file.Close()
 			if (len(retryObjCh)) == 0 {
@@ -152,7 +152,6 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject) {
 			}
 		}
 	}
-	logs.WriteToFailedLog()
 }
 
 func init() {

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -93,7 +93,7 @@ func init() {
 					file, err := os.Open(furObject.FilePath)
 					if err != nil {
 						log.Println("File open error: " + err.Error())
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
+						logs.AddToFailedLog(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						continue
 					}
@@ -102,7 +102,7 @@ func init() {
 					furObject, err := GenerateUploadRequest(furObject, file)
 					if err != nil {
 						file.Close()
-						logs.AddToFailedLogMap(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
+						logs.AddToFailedLog(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
 						logs.IncrementScore(logs.ScoreBoardLen - 1)
 						log.Printf("Error occurred during request generation: %s", err.Error())
 						continue
@@ -117,7 +117,6 @@ func init() {
 					file.Close()
 				}
 			}
-			logs.WriteToFailedLog()
 			logs.CloseAll()
 			logs.PrintScoreBoard()
 		},

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -39,8 +39,7 @@ func init() {
 			}
 			filename := filepath.Base(filePath)
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {
-				logs.AddToFailedLogMap(filePath, filename, "", 0, false, true)
-				logs.WriteToFailedLog()
+				logs.AddToFailedLog(filePath, filename, "", 0, false, true)
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
 				logs.CloseAll()
@@ -49,8 +48,7 @@ func init() {
 
 			file, err := os.Open(filePath)
 			if err != nil {
-				logs.AddToFailedLogMap(filePath, filename, "", 0, false, true)
-				logs.WriteToFailedLog()
+				logs.AddToFailedLog(filePath, filename, "", 0, false, true)
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
 				logs.CloseAll()
@@ -63,8 +61,7 @@ func init() {
 			furObject, err = GenerateUploadRequest(furObject, file)
 			if err != nil {
 				file.Close()
-				logs.AddToFailedLogMap(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
-				logs.WriteToFailedLog()
+				logs.AddToFailedLog(furObject.FilePath, furObject.Filename, furObject.GUID, 0, false, true)
 				logs.IncrementScore(logs.ScoreBoardLen - 1)
 				logs.PrintScoreBoard()
 				logs.CloseAll()
@@ -77,7 +74,6 @@ func init() {
 			} else {
 				logs.IncrementScore(0) // update succeeded score
 			}
-			logs.WriteToFailedLog()
 			logs.CloseAll()
 			logs.PrintScoreBoard()
 		},

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -53,7 +53,7 @@ func init() {
 				for _, filePath := range singlepartFilePaths {
 					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
+						logs.AddToFailedLog(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("Process filename error: " + err.Error())
 						continue
 					}
@@ -77,35 +77,37 @@ func init() {
 						}
 					}
 				}
-				logs.WriteToFailedLog()
 			} else {
 				for _, filePath := range singlepartFilePaths {
 					file, err := os.Open(filePath)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
+						logs.AddToFailedLog(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("File open error: " + err.Error())
 						continue
 					}
 
 					fi, err := file.Stat()
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
+						logs.AddToFailedLog(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("File stat error for file" + fi.Name() + ", file may be missing or unreadable because of permissions.\n")
 						continue
 					}
 					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
+						logs.AddToFailedLog(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("Process filename error for file: " + err.Error())
 						continue
 					}
 					// The following flow is for singlepart upload flow
 					respURL, guid, err := GeneratePresignedURL(fileInfo.Filename)
 					if err != nil {
-						logs.AddToFailedLogMap(fileInfo.FilePath, fileInfo.Filename, guid, 0, false, true)
+						logs.AddToFailedLog(fileInfo.FilePath, fileInfo.Filename, guid, 0, false, true)
 						log.Println(err.Error())
 						continue
 					}
+					// update failed log with new guid
+					logs.AddToFailedLog(fileInfo.FilePath, fileInfo.Filename, guid, 0, false, true)
+
 					furObject := commonUtils.FileUploadRequestObject{FilePath: fileInfo.FilePath, Filename: fileInfo.Filename, GUID: guid, PresignedURL: respURL}
 					furObject, err = GenerateUploadRequest(furObject, file)
 					if err != nil {
@@ -121,7 +123,6 @@ func init() {
 					}
 					file.Close()
 				}
-				logs.WriteToFailedLog()
 			}
 
 			// multipart upload for large files here
@@ -130,7 +131,7 @@ func init() {
 				for _, filePath := range multipartFilePaths {
 					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName)
 					if err != nil {
-						logs.AddToFailedLogMap(filePath, filepath.Base(filePath), "", 0, false, true)
+						logs.AddToFailedLog(filePath, filepath.Base(filePath), "", 0, false, true)
 						log.Println("Process filename error for file: " + err.Error())
 						continue
 					}

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -355,7 +355,7 @@ func validateFilePath(filePaths []string, forceMultipart bool) ([]string, []stri
 			}
 
 			if logs.ExistsInSucceededLog(filePath) {
-				log.Println("File \"" + filePath + "\" has been found in local submission history and has be skipped for preventing duplicated submissions.")
+				log.Println("File \"" + filePath + "\" has been found in local submission history and has been skipped for preventing duplicated submissions.")
 				return
 			}
 			logs.AddToFailedLog(filePath, filepath.Base(filePath), "", 0, false, true)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -281,8 +281,6 @@ func GenerateUploadRequest(furObject commonUtils.FileUploadRequestObject, file *
 	bar := pb.New64(fi.Size()).SetUnits(pb.U_BYTES).SetRefreshRate(time.Millisecond * 10).Prefix(furObject.Filename + " ")
 	pr, pw := io.Pipe()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
 	go func() {
 		var writer io.Writer
 		defer pw.Close()
@@ -295,9 +293,7 @@ func GenerateUploadRequest(furObject commonUtils.FileUploadRequestObject, file *
 		if err = pw.Close(); err != nil {
 			err = errors.New("Pipe writer close error: " + err.Error() + "\n")
 		}
-		wg.Done()
 	}()
-	wg.Wait()
 	if err != nil {
 		return furObject, err
 	}

--- a/gen3-client/logs/failed.go
+++ b/gen3-client/logs/failed.go
@@ -75,27 +75,27 @@ func GetFailedLogMap() map[string]commonUtils.RetryObject {
 	return failedLogFileMap
 }
 
-func AddToFailedLogMap(filePath string, filename string, guid string, retryCount int, isMultipart bool, isMuted bool) {
+func AddToFailedLog(filePath string, filename string, guid string, retryCount int, isMultipart bool, isMuted bool) {
 	failedLogLock.Lock()
 	defer failedLogLock.Unlock()
 	failedLogFileMap[filePath] = commonUtils.RetryObject{FilePath: filePath, Filename: filename, GUID: guid, RetryCount: retryCount, Multipart: isMultipart}
 	if !isMuted {
 		log.Printf("Failed file entry added for %s\n", filePath)
 	}
+	writeToFailedLog()
 }
 
-func DeleteFromFailedLogMap(filePath string, isMuted bool) {
+func DeleteFromFailedLog(filePath string, isMuted bool) {
 	failedLogLock.Lock()
 	defer failedLogLock.Unlock()
 	delete(failedLogFileMap, filePath)
 	if !isMuted {
 		log.Printf("Failed file entry deleted for %s\n", filePath)
 	}
+	writeToFailedLog()
 }
 
-func WriteToFailedLog() {
-	failedLogLock.Lock()
-	defer failedLogLock.Unlock()
+func writeToFailedLog() {
 	var tempSlice []commonUtils.RetryObject
 	for _, v := range failedLogFileMap {
 		tempSlice = append(tempSlice, v)


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-4520 by fixing a bug within the retry upload logic

### New Features


### Breaking Changes


### Bug Fixes
- fixed a bug that is not deleting residual indexd records when retrying upload
- fixed a bug that is not correctly handling retry upload logic for files require multipart upload
- fixed some typo (PXP-3346)

### Improvements
- failed log file is updated more frequently to ensure accuracy


### Dependency updates


### Deployment changes

