### PR TITLE
Fix/log

### DIFF
--- a/gen3-client/g3cmd/auth.go
+++ b/gen3-client/g3cmd/auth.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
+	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 )
 
 func init() {
@@ -16,6 +17,8 @@ func init() {
 		Long:    `Gets data access privileges for specified profile.`,
 		Example: `./gen3-client auth --profile=<profile-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
+			// don't initialize transmission logs for non-uploading related commands
+			logs.SetToBoth()
 
 			request := new(jwt.Request)
 			configure := new(jwt.Configure)
@@ -54,6 +57,7 @@ func init() {
 					}
 				}
 			}
+			logs.CloseMessageLog()
 		},
 	}
 

--- a/gen3-client/g3cmd/configure.go
+++ b/gen3-client/g3cmd/configure.go
@@ -3,6 +3,7 @@ package g3cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
+	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 )
 
 var conf jwt.Configure
@@ -18,6 +19,8 @@ func init() {
 	If no profile is specified, "default" profile is used`,
 		Example: `./gen3-client configure --profile=<profile-name> --cred=<path-to-credential/cred.json> --apiendpoint=https://data.mycommons.org`,
 		Run: func(cmd *cobra.Command, args []string) {
+			// don't initialize transmission logs for non-uploading related commands
+			logs.SetToBoth()
 
 			cred := conf.ReadCredentials(credFile)
 			conf.ValidateUrl(apiEndpoint)
@@ -28,6 +31,7 @@ func init() {
 				panic(err)
 			}
 			conf.UpdateConfigFile(cred, content, apiEndpoint, configPath, profile)
+			logs.CloseMessageLog()
 		},
 	}
 

--- a/gen3-client/g3cmd/configure.go
+++ b/gen3-client/g3cmd/configure.go
@@ -15,8 +15,7 @@ func init() {
 		Use:   "configure",
 		Short: "Add or modify a configuration profile to your config file",
 		Long: `Configuration file located at ~/.gen3/config
-	If a field is left empty, the existing value (if it exists) will remain unchanged
-	If no profile is specified, "default" profile is used`,
+	If a field is left empty, the existing value (if it exists) will remain unchanged`,
 		Example: `./gen3-client configure --profile=<profile-name> --cred=<path-to-credential/cred.json> --apiendpoint=https://data.mycommons.org`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// don't initialize transmission logs for non-uploading related commands

--- a/gen3-client/g3cmd/configure.go
+++ b/gen3-client/g3cmd/configure.go
@@ -1,6 +1,8 @@
 package g3cmd
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 	"github.com/uc-cdis/gen3-client/gen3-client/jwt"
 	"github.com/uc-cdis/gen3-client/gen3-client/logs"
@@ -27,7 +29,7 @@ func init() {
 			// Store user info in ~/.gen3/config
 			configPath, content, err := conf.TryReadConfigFile()
 			if err != nil {
-				panic(err)
+				log.Fatalln("Error occurred when trying to read config file: " + err.Error())
 			}
 			conf.UpdateConfigFile(cred, content, apiEndpoint, configPath, profile)
 			logs.CloseMessageLog()

--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/uc-cdis/gen3-client/gen3-client/commonUtils"
+	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 	pb "gopkg.in/cheggaaa/pb.v1"
 
 	"github.com/spf13/cobra"
@@ -323,6 +324,8 @@ func init() {
 		Long:    `Get presigned URLs for multiple of files specified in a manifest file and then download all of them.`,
 		Example: `./gen3-client download-multiple --profile=<profile-name> --manifest=<path-to-manifest/manifest.json> --download-path=<path-to-file-dir/>`,
 		Run: func(cmd *cobra.Command, args []string) {
+			// don't initialize transmission logs for non-uploading related commands
+			logs.SetToBoth()
 
 			var objects []ManifestObject
 			manifestBytes, err := ioutil.ReadFile(manifestPath)
@@ -341,6 +344,7 @@ func init() {
 				}
 			}
 			downloadFile(guids, downloadPath, filenameFormat, rename, noPrompt, protocol, numParallel, skipCompleted)
+			logs.CloseMessageLog()
 		},
 	}
 

--- a/gen3-client/g3cmd/download-single.go
+++ b/gen3-client/g3cmd/download-single.go
@@ -2,6 +2,7 @@ package g3cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 )
 
 func init() {
@@ -19,9 +20,13 @@ func init() {
 		Long:    `Gets a presigned URL for a file from a GUID and then downloads the specified file.`,
 		Example: `./gen3-client download-single --profile=<profile-name> --guid=206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc`,
 		Run: func(cmd *cobra.Command, args []string) {
+			// don't initialize transmission logs for non-uploading related commands
+			logs.SetToBoth()
+
 			guids := make([]string, 0)
 			guids = append(guids, guid)
 			downloadFile(guids, downloadPath, filenameFormat, rename, noPrompt, protocol, 1, skipCompleted)
+			logs.CloseMessageLog()
 		},
 	}
 

--- a/gen3-client/g3cmd/generate-tsv.go
+++ b/gen3-client/g3cmd/generate-tsv.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 )
 
 func computeMD5(file string) string {
@@ -37,6 +38,9 @@ func init() {
 		Example: `./gen3-client generate-tsv --from-template=image_file.tsv files*.dcm`,
 		Args:    cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			// don't initialize transmission logs for non-uploading related commands
+			logs.SetToBoth()
+
 			outFile, err := os.Create(output)
 			if err != nil {
 				log.Fatalf(err.Error())
@@ -94,7 +98,7 @@ func init() {
 			}
 
 			fmt.Printf("Generated tsv %v from files %v!\n", output, args[0])
-
+			logs.CloseMessageLog()
 		},
 	}
 

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -161,12 +161,17 @@ func init() {
 		Long:    `Re-submit files found in a given failed log by using sequential (non-batching) uploading and exponential backoff.`,
 		Example: "For retrying file upload:\n./gen3-client retry-upload --profile=<profile-name> --failed-log-path=<path-to-failed-log>\n",
 		Run: func(cmd *cobra.Command, args []string) {
+			// initialize transmission logs
+			logs.InitSucceededLog(profile)
+			logs.InitFailedLog(profile)
+			logs.SetToBoth()
+			logs.InitScoreBoard(MaxRetryCount)
+
 			failedLogPath = commonUtils.ParseRootPath(failedLogPath)
 			logs.LoadFailedLogFile(failedLogPath)
-			logs.InitScoreBoard(MaxRetryCount)
 			retryUpload(logs.GetFailedLogMap())
-			logs.CloseAll()
 			logs.PrintScoreBoard()
+			logs.CloseAll()
 		},
 	}
 

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -66,7 +66,4 @@ func initConfig() {
 	logs.Init()
 	logs.InitMessageLog(profile)
 	logs.SetToMessageLog()
-	logs.InitSucceededLog(profile)
-	logs.InitFailedLog(profile)
-	logs.SetToBoth()
 }

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -50,7 +50,13 @@ func init() {
 
 			var objects []ManifestObject
 
+			// initialize transmission logs
+			logs.InitSucceededLog(profile)
+			logs.InitFailedLog(profile)
+			logs.SetToBoth()
+			logs.InitScoreBoard(MaxRetryCount)
 			logs.InitScoreBoard(0)
+
 			manifestFile, err := os.Open(manifestPath)
 			if err != nil {
 				log.Println("Failed to open manifest file")
@@ -117,8 +123,8 @@ func init() {
 					file.Close()
 				}
 			}
-			logs.CloseAll()
 			logs.PrintScoreBoard()
+			logs.CloseAll()
 		},
 	}
 

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -25,7 +25,12 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Notice: this is the upload method which requires the user to provide a GUID. In this method file will be uploaded to a specified GUID.\nIf your intention is to upload file without pre-existing GUID, consider to use \"./gen3-client upload\" instead.\n\n")
 
+			// initialize transmission logs
+			logs.InitSucceededLog(profile)
+			logs.InitFailedLog(profile)
+			logs.SetToBoth()
 			logs.InitScoreBoard(0)
+
 			filePaths, err := commonUtils.ParseFilePaths(filePath)
 			if len(filePaths) > 1 {
 				fmt.Println("More than 1 file location has been found. Do not use \"*\" in file path or provide a folder as file path.")
@@ -74,8 +79,8 @@ func init() {
 			} else {
 				logs.IncrementScore(0) // update succeeded score
 			}
-			logs.CloseAll()
 			logs.PrintScoreBoard()
+			logs.CloseAll()
 		},
 	}
 

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -26,7 +26,12 @@ func init() {
 			"Can also support regex such as:\n./gen3-client upload --profile=<profile-name> --upload-path=<path-to-files/folder/*>\n" +
 			"Or:\n./gen3-client upload --profile=<profile-name> --upload-path=<path-to-files/*/folder/*.bam>",
 		Run: func(cmd *cobra.Command, args []string) {
+			// initialize transmission logs
+			logs.InitSucceededLog(profile)
+			logs.InitFailedLog(profile)
+			logs.SetToBoth()
 			logs.InitScoreBoard(MaxRetryCount)
+
 			uploadPath, _ = commonUtils.GetAbsolutePath(uploadPath)
 			filePaths, err := commonUtils.ParseFilePaths(uploadPath)
 			if err != nil {
@@ -147,8 +152,8 @@ func init() {
 			if !logs.IsFailedLogMapEmpty() {
 				retryUpload(logs.GetFailedLogMap())
 			}
-			logs.CloseAll()
 			logs.PrintScoreBoard()
+			logs.CloseAll()
 		},
 	}
 

--- a/gen3-client/gdcHmac/common.go
+++ b/gen3-client/gdcHmac/common.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -20,7 +21,6 @@ type location struct {
 }
 
 var loc *location
-
 
 // ServiceAndRegion parsers a hostname to find out which ones it is.
 // http://docs.aws.amazon.com/general/latest/gr/rande.html
@@ -102,7 +102,7 @@ func ReadAndReplaceBody(request *http.Request) []byte {
 	}
 	payload, err := ioutil.ReadAll(request.Body)
 	if err != nil {
-		panic(err)
+		log.Fatalln("error occurred when reading request body: " + err.Error())
 	}
 	request.Body = ioutil.NopCloser(bytes.NewReader(payload))
 	return payload

--- a/gen3-client/jwt/configure.go
+++ b/gen3-client/jwt/configure.go
@@ -213,7 +213,7 @@ func (conf *Configure) ParseConfig(profile string) Credential {
 	*/
 	homeDir, err := homedir.Dir()
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalln("Error occurred when getting home directory: " + err.Error())
 	}
 	configPath := path.Join(homeDir + commonUtils.PathSeparator + ".gen3" + commonUtils.PathSeparator + "config")
 	cred := Credential{
@@ -228,11 +228,11 @@ func (conf *Configure) ParseConfig(profile string) Credential {
 			"Example: ./gen3-client configure --profile=<profile-name> --cred=<path-to-credential/cred.json> --apiendpoint=https://data.mycommons.org")
 		return cred
 	}
-	// If profile not in config file, prompt user to set up config first
 
+	// If profile not in config file, prompt user to set up config first
 	content, err := ioutil.ReadFile(configPath)
 	if err != nil {
-		panic(err)
+		log.Fatalln("Error occurred when reading config file: " + err.Error())
 	}
 	lines := strings.Split(string(content), "\n")
 
@@ -245,16 +245,14 @@ func (conf *Configure) ParseConfig(profile string) Credential {
 	}
 
 	if profileLine == -1 {
-		log.Println("Profile not in config file. Need to run \"gen3-client configure --profile=" + profile + " --cred=<path-to-credential/cred.json> --apiendpoint=<api_endpoint_url>\" first")
-		return cred
-	} else {
-		// Read in access key, secret key, endpoint for given profile
-		cred.KeyId = conf.ParseKeyValue(lines[profileLine+1], "^key_id=(\\S*)", "key_id not found in profile")
-		cred.APIKey = conf.ParseKeyValue(lines[profileLine+2], "^api_key=(\\S*)", "api_key not found in profile")
-		cred.AccessKey = conf.ParseKeyValue(lines[profileLine+3], "^access_key=(\\S*)", "access_key not found in profile")
-		cred.APIEndpoint = conf.ParseKeyValue(lines[profileLine+4], "^api_endpoint=(\\S*)", "api_endpoint not found in profile")
-		return cred
+		log.Fatalln("Profile not in config file. Need to run \"gen3-client configure --profile=" + profile + " --cred=<path-to-credential/cred.json> --apiendpoint=<api_endpoint_url>\" first")
 	}
+	// Read in access key, secret key, endpoint for given profile
+	cred.KeyId = conf.ParseKeyValue(lines[profileLine+1], "^key_id=(\\S*)", "key_id not found in profile")
+	cred.APIKey = conf.ParseKeyValue(lines[profileLine+2], "^api_key=(\\S*)", "api_key not found in profile")
+	cred.AccessKey = conf.ParseKeyValue(lines[profileLine+3], "^access_key=(\\S*)", "access_key not found in profile")
+	cred.APIEndpoint = conf.ParseKeyValue(lines[profileLine+4], "^api_endpoint=(\\S*)", "api_endpoint not found in profile")
+	return cred
 }
 
 func (conf *Configure) TryReadFile(filePath string) ([]byte, error) {

--- a/gen3-client/jwt/configure.go
+++ b/gen3-client/jwt/configure.go
@@ -40,6 +40,7 @@ func (conf *Configure) ReadFile(filePath string, fileType string) string {
 	fullFilePath, err := commonUtils.GetAbsolutePath(filePath)
 	if err != nil {
 		log.Println("error occurred when parsing config file path: " + err.Error())
+		return ""
 	}
 	if _, err := os.Stat(fullFilePath); err != nil {
 		log.Println("File specified at " + fullFilePath + " not found")
@@ -48,7 +49,8 @@ func (conf *Configure) ReadFile(filePath string, fileType string) string {
 
 	content, err := ioutil.ReadFile(fullFilePath)
 	if err != nil {
-		panic(err)
+		log.Println("error occurred when reading file: " + err.Error())
+		return ""
 	}
 
 	contentStr := string(content[:])
@@ -141,11 +143,11 @@ func (conf *Configure) UpdateConfigFile(cred Credential, configContent []byte, a
 	if found {
 		f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_TRUNC, 0777)
 		if err != nil {
-			panic(err)
+			log.Fatalln("error occurred when opening config file: " + err.Error())
 		}
 		defer func() {
 			if err := f.Close(); err != nil {
-				panic(err)
+				log.Println("error occurred when closing config file: " + err.Error())
 			}
 		}()
 		for i := 0; i < len(lines)-1; i++ {
@@ -154,11 +156,11 @@ func (conf *Configure) UpdateConfigFile(cred Credential, configContent []byte, a
 	} else {
 		f, err := os.OpenFile(configPath, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
 		if err != nil {
-			panic(err)
+			log.Fatalln("error occurred when opening config file: " + err.Error())
 		}
 		defer func() {
 			if err := f.Close(); err != nil {
-				panic(err)
+				log.Println("error occurred when closing config file: " + err.Error())
 			}
 		}()
 
@@ -169,7 +171,7 @@ func (conf *Configure) UpdateConfigFile(cred Credential, configContent []byte, a
 			"api_endpoint=" + apiEndpoint + "\n\n")
 
 		if err != nil {
-			panic(err)
+			log.Println("error occurred when updating config: " + err.Error())
 		}
 	}
 }
@@ -177,11 +179,11 @@ func (conf *Configure) UpdateConfigFile(cred Credential, configContent []byte, a
 func (conf *Configure) ParseKeyValue(str string, expr string, errMsg string) string {
 	r, err := regexp.Compile(expr)
 	if err != nil {
-		panic(err)
+		log.Fatalln("error occurred when parsing key/value: " + err.Error())
 	}
 	match := r.FindStringSubmatch(str)
 	if len(match) == 0 {
-		log.Fatal(errMsg)
+		log.Fatalln(errMsg)
 	}
 	return match[1]
 }

--- a/gen3-client/logs/logs-master.go
+++ b/gen3-client/logs/logs-master.go
@@ -13,7 +13,7 @@ var MainLogPath string
 func Init() {
 	homeDir, err := homedir.Dir()
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalln("Error occurred when getting home directory: " + err.Error())
 	}
 
 	mainPath := homeDir + commonUtils.PathSeparator + ".gen3" + commonUtils.PathSeparator
@@ -39,8 +39,8 @@ func CloseAll() {
 	errorSlice := make([]error, 0)
 	errorSlice = append(errorSlice, closeSucceededLog())
 	errorSlice = append(errorSlice, closeFailedLog())
-	errorSlice = append(errorSlice, closeMessageLog())
-	log.SetOutput(os.Stdout)
+	errorSlice = append(errorSlice, CloseMessageLog())
+	SetToConsole()
 	for _, err := range errorSlice {
 		if err != nil {
 			log.Println(err.Error())

--- a/gen3-client/logs/system-msg.go
+++ b/gen3-client/logs/system-msg.go
@@ -39,7 +39,7 @@ func SetToBoth() {
 	log.SetOutput(multiWriter)
 }
 
-func closeMessageLog() error {
+func CloseMessageLog() error {
 	SetToMessageLog()
 	log.Println("Local message log file \"" + messageLogFilename + "\" has closed")
 	return messageLogFile.Close()


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes
- fixed a bug with errored profile config: program should exit instead of continue

### Improvements
- only create `succeeded` and `failed` logs for upload-related commands
- don't panic, use log.Fatal or log.Print instead
 
### Dependency updates


### Deployment changes

