### PR TITLE
PXP-2451 feat/version checker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN go get github.com/mitchellh/go-homedir \
     github.com/spf13/viper \
     github.com/cavaliercoder/grab \
     github.com/golang/mock/gomock \
+    github.com/tcnksm/go-latest \
     gopkg.in/cheggaaa/pb.v1
 
 COPY . .

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -2,11 +2,13 @@ package g3cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	latest "github.com/tcnksm/go-latest"
 	"github.com/uc-cdis/gen3-client/gen3-client/logs"
 )
 
@@ -65,5 +67,20 @@ func initConfig() {
 
 	logs.Init()
 	logs.InitMessageLog(profile)
+	logs.SetToBoth()
+	// version checker
+	if gitversion != "" && gitversion != "N/A" {
+		githubTag := &latest.GithubTag{
+			Owner:      "uc-cdis",
+			Repository: "cdis-data-client",
+		}
+		res, err := latest.Check(githubTag, gitversion)
+		if err != nil {
+			log.Println("Error occurred when checking for latest version: " + err.Error())
+		} else if res.Outdated {
+			log.Println("A new version of gen3-client is avaliable! The latest version is " + res.Current + ". You are using version " + gitversion)
+			log.Println("Please download the latest gen3-client release from https://github.com/uc-cdis/cdis-data-client/releases/latest")
+		}
+	}
 	logs.SetToMessageLog()
 }

--- a/gen3-client/logs/system-msg.go
+++ b/gen3-client/logs/system-msg.go
@@ -22,7 +22,7 @@ func InitMessageLog(profile string) {
 		messageLogFile.Close()
 		log.Fatalln("Error occurred when opening file \"" + messageLogFilename + "\": " + err.Error())
 	}
-	multiWriter = io.MultiWriter(os.Stdout, messageLogFile)
+	multiWriter = io.MultiWriter(os.Stderr, messageLogFile)
 	log.SetOutput(messageLogFile)
 	log.Println("Local message log file \"" + messageLogFilename + "\" has opened")
 }
@@ -32,7 +32,7 @@ func SetToMessageLog() {
 }
 
 func SetToConsole() {
-	log.SetOutput(os.Stdout)
+	log.SetOutput(os.Stderr)
 }
 
 func SetToBoth() {


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-2451

If an user is using an old version gen3-client, he/she will see the following message in console when running any gen3-client commands
> A new version of gen3-client is avaliable! The latest version is ${LATEST_VERSION}. You are using version ${CURRENT_VERSION}
Please download the latest gen3-client release from https://github.com/uc-cdis/cdis-data-client/releases/latest

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- A version checker is added to check if there is a newer `gen3-client` release and notify the user
- log console outputs now directed to `os.Stderr` insted of `os.Stdout`

### Dependency updates


### Deployment changes

