### PR TITLE
Fix for nil pointer dereference in MakeARequest

### DIFF
--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -54,7 +54,14 @@ func (r *Request) MakeARequest(method string, apiEndpoint string, accessKey stri
 		headers["Content-Type"] = contentType
 	}
 	client := &http.Client{Timeout: commonUtils.DefaultTimeout}
-	req, err := http.NewRequest(method, apiEndpoint, body)
+	var req *http.Request
+	var err error
+	if body == nil {
+		req, err = http.NewRequest(method, apiEndpoint, nil)
+	} else {
+		req, err = http.NewRequest(method, apiEndpoint, body)
+	}
+
 	if err != nil {
 		return nil, errors.New("Error occurred during generating HTTP request: " + err.Error())
 	}


### PR DESCRIPTION
Jira ticket: [PXP-7104](https://ctds-planx.atlassian.net/browse/PXP-7104)

- NOTE: Bug was caused by nil body passed to MakeARequest, which was then
passed to http.NewRequest. http.NewRequest panics if passed a nil reference
(but not nil, see: https://github.com/golang/go/issues/32897). Fixed by explicitly
passing MakeARequest nil if body is nil.

### Bug Fixes
- Fix critical bug causing errors in `download-single` and `download-multiple` commands. 
