### PR TITLE
chore(release): Overwrite files when re-creating releases

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-09-09T21:04:45Z",
+  "generated_at": "2020-11-04T22:50:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -61,58 +61,50 @@
     ".travis.yml": [
       {
         "hashed_secret": "a5f237e9a674509f401b9b10fd961f8ef273d3c8",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 30,
         "type": "Base64 High Entropy String"
       }
     ],
     "gen3-client/gdcHmac/gdcAuth_test.go": [
       {
         "hashed_secret": "bc132b78182e884ff66ff351b4ea51a590d63ee5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 11,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "c82784abcdba73e5be51b06f03880751682691bc",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "346e9daf5584a6f0b4f5af2be15657c1e7708559",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 13,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "84087a2a51ccfe71a017e7b18b7bc569792041c7",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "a686e3eeae6d3a989d3fe69162a746ec22109d80",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 38,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "56c1d3d608e82b0d0153eb3912cdfcf33b61b4ea",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 85,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "d2658eaafd86a214e297753ca14d8716e078b99d",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 88,
         "type": "Base64 High Entropy String"
@@ -121,37 +113,1114 @@
     "gen3-client/jwt/configure.go": [
       {
         "hashed_secret": "2ace62c1befa19e3ea37dd52be9f6d508c5163e6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 174,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "4c85e7c51e03e596b7e4f1d78d30c4fce2ee1df4",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 208,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "a72b75fddaf62834933122c3ff0d5b1aab840719",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 216,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 234,
         "type": "Secret Keyword"
       }
     ],
+    "go.sum": [
+      {
+        "hashed_secret": "805060f42af90533927009784f99152611f70431",
+        "is_verified": false,
+        "line_number": 1,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a2d19e79da69df3078b86c28f4a67a5bdb6a6770",
+        "is_verified": false,
+        "line_number": 2,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "db65ea9cbb4a1361e244297719342c28e7d51617",
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8955b68f5d5d6f23e3414472aaa9eda268438389",
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "796f4bdf18ce60679a417486e8e63c2afa23a940",
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5fc563d9d056ce180a9fb704d0c87850f373db6c",
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f3255dbab13c1a75411a953af9f35eb4605ff867",
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "70614b88ea59d812941be29f128a5c0bf59a5e83",
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "47821989b41e1574aa5c450b319eafe891050f45",
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "47213b35998301830d409d5cc0cebd65ff8aad77",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "731fa3e16d6ca6a8e0e0eeb04cb3a55c3089ff62",
+        "is_verified": false,
+        "line_number": 11,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "57b7c84bb495816dec158c369da99ed4f16395b9",
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "843d8779cc537bd6e13f99ca35b5a56ef79d2088",
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "130f1496d16c1053c2dbce2f08ba45a46e556bcb",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "037dbea74b5915d1c8dcfdb47d0bfa1583842fb6",
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c103a3446fa258ba442135171ecc22960fc1f0dc",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "935ed769c805dbbda357d77dfc690bfb16c09b6e",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e7d2b52449737744aa82f66895db6409dd7efc89",
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4dbbe18874344f8a812138c0c9b17841a5fab11d",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "79befee73277f9f0de1646547837b5a9925741a5",
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b15842073bbf57c27ccefb6a28606de9af08888b",
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4eb0825d39780902b37130f79c2af000f2ad8847",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0ffe9eee2c6235293058686c7c0cbc1a54d4d51c",
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9b6c145409d2eae4324859d62474b75798354adb",
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b5d652e0682d37e31f140ad41f7774e4fd920342",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8a9469749e482c5c2025bdf2443ca21c9e72afac",
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0f03ee0e517d17a211a42363aca8592714103a7d",
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "72e7fc62ebd862c6bd0e8c8b1bfb7f8050408664",
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "58c387e82ccaf09d4a0228ecc193d1ed78fd1b6f",
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "267a9e339e676abd5a3eefc9422d204e39d0a6cb",
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fa76a0b5cc9805fe25b433d3569ed4580f3974fd",
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "75c76cc98003d38945e2542109e9ac974dc8f3c8",
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "532ca40a0471fb9f0e837cf485eec3776c92c5ac",
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f9618f13b3be72a9702ea8a1b0f3a585253bec01",
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "58804a815bf34b933b2ce23cb5aaa535a6f18d5f",
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8892c9e2f31278bd26af1e1c6d243cf5fd2ef2eb",
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b25daf2f7eca00ab98094304d82eb05c28b5fc2d",
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4fb18fc74dca10136741c8fae75f110b36547ecb",
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b781bf77c077a3a0ea976837f207da5be0837206",
+        "is_verified": false,
+        "line_number": 42,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1125f2682ae37cc96a002caf0c5ea950838a093e",
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "aeb511122dc9b146fc95f2c1160549315f9bd87e",
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7e547ad766e9b4a711f1a1dd4b47436144c3990e",
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9b4680c47eda96cb75cbb26bd7c09811f7a3397b",
+        "is_verified": false,
+        "line_number": 46,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3e61cb7c969dbd63c89b942dd3372ec249ad202d",
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b66d571566471f99fc35c72f3a7d69e04bdd0a55",
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9ebb3eb8a046798d7d98e142d6ed89a9e172d61f",
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d9e0ddb1eec476c32e652f841c526c89e89c6490",
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5f72a7881f4654a0b60cc03ff54576bec7770d26",
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b9de6923d5a28e9193feedf03d42e9adac2a1043",
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "915eaa9864b2ac10f6334cc9e2f02bba86529a09",
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "01553db0e93326a40b3e68364a8bc76a9a9de518",
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "79c386e6eb1c9a1844e99eb4fe582dfaec72d9d8",
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "88cf6edcd84c368dba0c744567b46bd7afb83a6f",
+        "is_verified": false,
+        "line_number": 56,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "607dcca41a47db4a6d8ba8f0a4d8624693084592",
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7b9bc6d8359d5866b2f64fce6a27b1c7034309f2",
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c1b1278c181f536be351f06973df3e308d3d4a64",
+        "is_verified": false,
+        "line_number": 59,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "16f98a4ca47eafab4404a55af01555fb262f67d1",
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "08462dd7d7b07423a943b7fa1f6f722f89a7ca0d",
+        "is_verified": false,
+        "line_number": 61,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0a4dfcc141dc027fb4a3eb64c911223a9ccfe230",
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2fbb92cbf4b118fd1dc58911785950111bf21bad",
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4388c537e764c7c095adf066668caeae62303cb2",
+        "is_verified": false,
+        "line_number": 64,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b4cbe6a030aa8c3b94cb08e0c7609d158b9bcc88",
+        "is_verified": false,
+        "line_number": 65,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "165072218b4f9dbc6d6ef392a042c137b236a4eb",
+        "is_verified": false,
+        "line_number": 66,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "64f47246fa2614d8a7c370779782a48e38b6f22a",
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e41fea1ba75a9550dbf56ba7f4dd2f54a2e8ab62",
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0e8c6ab83025779440fb9f846a632a6403942d1a",
+        "is_verified": false,
+        "line_number": 69,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "040fb969a29154a8912624bf36ea0aadb3697a53",
+        "is_verified": false,
+        "line_number": 70,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "04fbfa683977ae04a5c0035936055d57ad16692c",
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "237f64c111ccc8fd3243a7fd7f7b06965ea3a0b8",
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a35fb83af05b415167bcb6022b179bf5e69b865f",
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3281c8f52dbb2e95e00f3bf25a175def72bc3aea",
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e290944119f3c96549650f798a928b2fb56cbdf5",
+        "is_verified": false,
+        "line_number": 76,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "37e607f3246491e6a510f8f48e6d78ac6f559bd3",
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c68d48f8b38dcc4e3949c876c64a4d9812b79f9d",
+        "is_verified": false,
+        "line_number": 78,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3e3cc3ef89d7404e9af36e12a7fffbfc82edcd7e",
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4b16e077113c0e8e8d3177797b84edac6be2f723",
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9c0c587116eaade36826d0d4c6d2ee28a421bf3d",
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "10a455909907f50d99ee333142405a90f4f8b984",
+        "is_verified": false,
+        "line_number": 82,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "96c7e8a1cb093d0206d8e720cc8073e58262a46a",
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e23197fba8fb7bea38067512da2ac3abb808aa4d",
+        "is_verified": false,
+        "line_number": 84,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ae49df5033deaf0f09972d525d9e26f4f38a4f4a",
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "df260473dfe7cd9b9096eb50e2749e74f420c4da",
+        "is_verified": false,
+        "line_number": 86,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9f3c1acb7758a594bdefb4f9d3e153b844803237",
+        "is_verified": false,
+        "line_number": 87,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fbe1c0510709b44229c4b3bb4518ff1984061659",
+        "is_verified": false,
+        "line_number": 88,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6caf16cacd5a67d7e49e298fe2d1343dc2ec9b05",
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6942e9a8146b1b122eaccc9bae6d5058a9103dd9",
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "17ad28111768d89abcb1313b96c068b6bcbe3365",
+        "is_verified": false,
+        "line_number": 91,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b38699d8705643a8973709b7e5ceeb6bb7a14761",
+        "is_verified": false,
+        "line_number": 92,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6bba0354504f72e495c0cbeda4fb278b6dcefe10",
+        "is_verified": false,
+        "line_number": 94,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ff10e44a9ff94dd0691318bdb5ae8f0b3ab8af76",
+        "is_verified": false,
+        "line_number": 95,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c553ab0c1273b969d73c3618537b4da93c5cf3f1",
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b99e66723ceb6c266be90ac139221e2155640eb4",
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c7650183a346ae042dc23cca37346be944b530e1",
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6a4a1948d9e9978e41ee2d466928b91e8ac5d54b",
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c382813ad978b45fb54312f408087e014b4374eb",
+        "is_verified": false,
+        "line_number": 101,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9c44e52745ca80e45adff4ead399bce998522c5a",
+        "is_verified": false,
+        "line_number": 102,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0916dd467cf744e33ca8a9d2e06fbdca61207483",
+        "is_verified": false,
+        "line_number": 103,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c761e96c6bc38faf2f7a629cfcd484643f1373d1",
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f7b7fe600ed0ad9ddffa170b9ff1600121f94dd4",
+        "is_verified": false,
+        "line_number": 105,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "28954f9c42a74ca5ccedb6af82b164b851fe13a0",
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "af965176875fb85254d0e7fc0a60aa8bf92fafa0",
+        "is_verified": false,
+        "line_number": 107,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "421e353fbec751ca5705a63c75b48c1db554142c",
+        "is_verified": false,
+        "line_number": 108,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ded86de4cb21afbb91a574210a02daa0fd8f5e88",
+        "is_verified": false,
+        "line_number": 109,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a72e4b1729a094182d4130d4d9b6b78b1f89fbd0",
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cb5a31c2b60354e7f3fe3a788538bb781b34a94f",
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8a66c8b4d36214865e0ba9cac208e7483cd57a09",
+        "is_verified": false,
+        "line_number": 113,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9c4f7448f4294139393f1036dabd06514efbe8ec",
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1f5d7747b1020323b2f78c635958293f6b045831",
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9c044d3e18f52f5f67e9ce7dac67818acc302c1e",
+        "is_verified": false,
+        "line_number": 116,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "366635373cb300e7b343d7c0d533a1b689a7155d",
+        "is_verified": false,
+        "line_number": 117,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ccacb0f103674a94a266df8f92ceba58c44ed34f",
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d5a03d3b9fd5c069fee4157d9c5415ef38f2b908",
+        "is_verified": false,
+        "line_number": 119,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d6e0195ceb10e3fdc0e0ab0d939c5ffd0625129f",
+        "is_verified": false,
+        "line_number": 120,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5293bdf8e1788729e3b4331076a13ba2ced70868",
+        "is_verified": false,
+        "line_number": 121,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d2a0d16c81997fd09954925a595bce4ee479a1e9",
+        "is_verified": false,
+        "line_number": 122,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0dba6e03d023a57e72f4cc53c0bab01d60871a90",
+        "is_verified": false,
+        "line_number": 123,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "14e2952d7cbde163feaea85ebd0724a0bf1a8a46",
+        "is_verified": false,
+        "line_number": 124,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1abedc1f10de72c9748a7d5d10a713e20f9d97f5",
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e50439a14896fd6f4ebfec0bd5f81a4d07c046bf",
+        "is_verified": false,
+        "line_number": 126,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9eabcc022d6728e33274a679b0dbe10f58d43646",
+        "is_verified": false,
+        "line_number": 127,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bf2eb45b380ebf5711abfbf54dd6c33403322783",
+        "is_verified": false,
+        "line_number": 128,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f61c692c836974a6d254c063607e3dde151bef88",
+        "is_verified": false,
+        "line_number": 129,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "db6db3bb4ad28447c392e3d8d43f5c22c9882dd9",
+        "is_verified": false,
+        "line_number": 130,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fdce6c2fbd8f3fc3eb35f5e802c121eeabc27f7e",
+        "is_verified": false,
+        "line_number": 131,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5af61c445f37eeef72a68442ab999beeee6f7995",
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f1fbe65ffd65f1ba2fb114ed52f60eb342ce777c",
+        "is_verified": false,
+        "line_number": 133,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f16e20544c05634663c76b999b6707da9f0ecbcc",
+        "is_verified": false,
+        "line_number": 135,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8d19507fdd8eb2c703e7fea913f2df6ca08b5491",
+        "is_verified": false,
+        "line_number": 136,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6befd736c9d2fdf056c960bb1469537e0588cda6",
+        "is_verified": false,
+        "line_number": 137,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3765eda8e7c792ffa4b4cfca6385122b32fcb9e0",
+        "is_verified": false,
+        "line_number": 138,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c0ef5d8d6df9a964e5ca5d158e9bcbc5751d8408",
+        "is_verified": false,
+        "line_number": 139,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4d79966a436e1c3352fc5e41f953a0aaf73cbc79",
+        "is_verified": false,
+        "line_number": 140,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9feb5bff32f2956fd3aea557659fc76f51b4dbe2",
+        "is_verified": false,
+        "line_number": 141,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "618aa1504ffb8b0d404a6e0f452ec8597d1102ec",
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "22aa11412cf8962f71ec71666d40ff09a11fe13e",
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1b48b510a0ade413e208c67a9275daa06f9a8bbb",
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "125764937dec90ca87d05490fc370dd344ad39ab",
+        "is_verified": false,
+        "line_number": 145,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6fb614c4967eaed4cfbc8a73eb0ce11ece610234",
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2f393cf1a36ffdf87db8c9e19f8b9e3f5b2adb12",
+        "is_verified": false,
+        "line_number": 147,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8c012dd6466ce4265d09ce1c9301bf3dfce2a105",
+        "is_verified": false,
+        "line_number": 148,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bb9c16e7f283c46a33cd2b3d381e063e2604580e",
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6eb556c996caa2f374d4fd635024111c2e927a96",
+        "is_verified": false,
+        "line_number": 150,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "244f22ac70a4f546b5065a109090f9fb3c469753",
+        "is_verified": false,
+        "line_number": 151,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0918088df56ab0144ab80845726914b6f5762aa9",
+        "is_verified": false,
+        "line_number": 152,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b9dc0fc2185123f961a0272645467a573f4a510c",
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6441b95a7933d863adc7bf7e86d1304affa08dc4",
+        "is_verified": false,
+        "line_number": 154,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bf5b914454bf2d472be60acb49a2e646cb1139a7",
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3bbee69c41c25a30b8b19a37c6b77570b259574e",
+        "is_verified": false,
+        "line_number": 158,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2a05c472db9c0c251e9be0e35cea9bde7891cce6",
+        "is_verified": false,
+        "line_number": 159,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f39f0c519f6e08260cc0a53bf2fd671bf475859a",
+        "is_verified": false,
+        "line_number": 160,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4e4eb920135a1d702110491607ef8e023e09c29a",
+        "is_verified": false,
+        "line_number": 161,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "af58e693e1b2d980ed923a3a65bacd88033d1c9d",
+        "is_verified": false,
+        "line_number": 165,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "de27f4794b81b46b33cbfd5af8084c587da736c1",
+        "is_verified": false,
+        "line_number": 170,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0ce1bbf44cfc3e9ac535b22293940f5ace10a031",
+        "is_verified": false,
+        "line_number": 172,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1f632be12fffb7ae80c4b5f35544b0159723948f",
+        "is_verified": false,
+        "line_number": 175,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ebce33ed93c15294766862efead26a0fe7c1b480",
+        "is_verified": false,
+        "line_number": 176,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "76887a8e280e8ec544715fd5844705edf5fa1e91",
+        "is_verified": false,
+        "line_number": 178,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6c76abe4bb26384b9ff06c9ef66352708b9368f1",
+        "is_verified": false,
+        "line_number": 179,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cb96d5b893ace0a7c70432880712884bd0ca8da4",
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4ef548550ab47a3cf6306d34075d8065ed95d0f1",
+        "is_verified": false,
+        "line_number": 182,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "686f5ffbbf045a101a04487965c6e49066bf4aba",
+        "is_verified": false,
+        "line_number": 184,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6e53111855c35c299633da1b62d67203126d40fa",
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "48dd831553495623ee9dc16333f6aea717810ef3",
+        "is_verified": false,
+        "line_number": 186,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c737747201cd7d6bacda07019643da2e2542f701",
+        "is_verified": false,
+        "line_number": 187,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fcc2d2db6345c5f51c1da77393f3a30234ead766",
+        "is_verified": false,
+        "line_number": 188,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "51befd6ba07f88cae13fc2172a77eca215fff0ae",
+        "is_verified": false,
+        "line_number": 189,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "342fc5e0243b95ced11c2b2e74df9b58c4405256",
+        "is_verified": false,
+        "line_number": 190,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7d76ae57bef6c4a87eab4fe657745dbfcbcefe08",
+        "is_verified": false,
+        "line_number": 192,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "aa945027601e7b92be504f177761e51cd2fc9293",
+        "is_verified": false,
+        "line_number": 193,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9b933558d1312768c39c18726eb6f3569664ee8b",
+        "is_verified": false,
+        "line_number": 194,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b5af5d2a9c25a8963041d32311d481922ff87730",
+        "is_verified": false,
+        "line_number": 195,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "78ecd2343843279cbb6e9cbd56b59105aa598c83",
+        "is_verified": false,
+        "line_number": 196,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f669d40693d001a064ff6980aed4bdf24658c85e",
+        "is_verified": false,
+        "line_number": 197,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "22ab62629f1db08b2915055e67bbe50173842927",
+        "is_verified": false,
+        "line_number": 198,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "77cbc0b96ef9a766afff6e330b8dc12a90674e17",
+        "is_verified": false,
+        "line_number": 199,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c42df26bf8e77601864f780c40ea06edc29386f0",
+        "is_verified": false,
+        "line_number": 202,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0bfcf978179e9b9371d132d9fd4065909f1fa3e6",
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a7907b2e77ffe68cb481542115c2deb4a6690563",
+        "is_verified": false,
+        "line_number": 204,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "42f105362550fc802f97f25e76a42455659010e3",
+        "is_verified": false,
+        "line_number": 205,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6e748dbaefd5e8d5752ef11c741ec73e25108f7f",
+        "is_verified": false,
+        "line_number": 206,
+        "type": "Base64 High Entropy String"
+      }
+    ],
     "tests/functions_test.go": [
       {
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 130,
         "type": "Secret Keyword"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
     - stage: deploy
       script: echo "Deploying to GitHub" && ls -al ~/shared
       deploy:
+        overwrite: true
         skip_cleanup: true
         provider: releases
         api_key:
@@ -83,5 +84,3 @@ script: |-
     fi
     set +e
   fi
-
-


### PR DESCRIPTION
We seem to be facing issues with lingering files with old commits in Travis while re-creating releases and zipped binaries.