### PR TITLE
PXP-6106 fix: auth cmd authz section

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-11-04T23:16:10Z",
+  "generated_at": "2021-03-02T20:12:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -140,7 +140,7 @@
       {
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 131,
         "type": "Secret Keyword"
       }
     ]

--- a/gen3-client/g3cmd/auth.go
+++ b/gen3-client/g3cmd/auth.go
@@ -57,10 +57,10 @@ func init() {
 							sort.Strings(access)
 							log.Printf("%s %s\n", project, access)
 						} else {
-							// Premissions from Arborist already sorted, just pretty print them
+							// Permissions from Arborist already sorted, just pretty print them
 							marshalledPermissions, err := json.MarshalIndent(permissions, "", "  ")
 							if err != nil {
-								log.Printf("%s (error occurred when marshalling premissions): %s\n", project, err)
+								log.Printf("%s (error occurred when marshalling permissions): %s\n", project, err)
 							}
 							log.Printf("%s %s\n", project, marshalledPermissions)
 						}

--- a/gen3-client/g3cmd/auth.go
+++ b/gen3-client/g3cmd/auth.go
@@ -1,6 +1,7 @@
 package g3cmd
 
 import (
+	"encoding/json"
 	"log"
 	"sort"
 
@@ -13,8 +14,8 @@ func init() {
 
 	var authCmd = &cobra.Command{
 		Use:     "auth",
-		Short:   "Return data access privileges from profile",
-		Long:    `Gets data access privileges for specified profile.`,
+		Short:   "Return resource access privileges from profile",
+		Long:    `Gets resource access privileges for specified profile.`,
 		Example: `./gen3-client auth --profile=<profile-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// don't initialize transmission logs for non-uploading related commands
@@ -27,33 +28,42 @@ func init() {
 			function.Request = request
 			function.Config = configure
 
-			host, projectAccess, err := function.CheckPrivileges(profile, "")
+			host, resourceAccess, err := function.CheckPrivileges(profile, "")
 
 			if err != nil {
 				log.Fatalf("Fatal authentication error: %s\n", err)
 			} else {
-				if len(projectAccess) == 0 {
-					log.Printf("\nYou don't currently have access to data from any projects at %s\n", host)
+				if len(resourceAccess) == 0 {
+					log.Printf("\nYou don't currently have access to any resources at %s\n", host)
 				} else {
-					log.Printf("\nYou have access to the following project(s) at %s:\n", host)
+					log.Printf("\nYou have access to the following resource(s) at %s:\n", host)
 
-					// Sort by project name
-					projects := make([]string, 0, len(projectAccess))
-					for project := range projectAccess {
-						projects = append(projects, project)
+					// Sort by resource name
+					resources := make([]string, 0, len(resourceAccess))
+					for resource := range resourceAccess {
+						resources = append(resources, resource)
 					}
-					sort.Strings(projects)
+					sort.Strings(resources)
 
-					for _, project := range projects {
-						// Sort by access name
-						permissions := projectAccess[project].([]interface{})
-						access := make([]string, 0, len(permissions))
-						for _, permission := range permissions {
-							access = append(access, permission.(string))
+					for _, project := range resources {
+						// Sort by access name if permissions are from Fence
+						permissions := resourceAccess[project].([]interface{})
+						_, isFencePermission := permissions[0].(string)
+						if isFencePermission {
+							access := make([]string, 0, len(permissions))
+							for _, permission := range permissions {
+								access = append(access, permission.(string))
+							}
+							sort.Strings(access)
+							log.Printf("%s %s\n", project, access)
+						} else {
+							// Premissions from Arborist already sorted, just pretty print them
+							marshalledPermissions, err := json.MarshalIndent(permissions, "", "  ")
+							if err != nil {
+								log.Printf("%s (error occurred when marshalling premissions): %s\n", project, err)
+							}
+							log.Printf("%s %s\n", project, marshalledPermissions)
 						}
-						sort.Strings(access)
-
-						log.Printf("%s %s\n", project, access)
 					}
 				}
 			}

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -296,12 +296,17 @@ func (f *Functions) CheckPrivileges(profile string, configFileType string) (stri
 		return "", nil, errors.New("Error occurred when unmarshalling response: " + err.Error())
 	}
 
-	projectAccess, ok := data["project_access"].(map[string]interface{})
-	if !ok {
-		return "", nil, errors.New("Not possible to read user access privileges")
+	resourceAccess, ok := data["authz"].(map[string]interface{})
+
+	// If the `authz` section (Arborist premissions) is empty or missing, try get `project_access` section (Fence premissions)
+	if len(resourceAccess) == 0 || !ok {
+		resourceAccess, ok = data["project_access"].(map[string]interface{})
+		if !ok {
+			return "", nil, errors.New("Not possible to read access privileges of user")
+		}
 	}
 
-	return host, projectAccess, err
+	return host, resourceAccess, err
 }
 
 func (f *Functions) DeleteRecord(profile string, configFileType string, guid string) (string, error) {

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -298,7 +298,7 @@ func (f *Functions) CheckPrivileges(profile string, configFileType string) (stri
 
 	resourceAccess, ok := data["authz"].(map[string]interface{})
 
-	// If the `authz` section (Arborist premissions) is empty or missing, try get `project_access` section (Fence premissions)
+	// If the `authz` section (Arborist permissions) is empty or missing, try get `project_access` section (Fence permissions)
 	if len(resourceAccess) == 0 || !ok {
 		resourceAccess, ok = data["project_access"].(map[string]interface{})
 		if !ok {

--- a/tests/functions_test.go
+++ b/tests/functions_test.go
@@ -209,7 +209,7 @@ func TestCheckPrivilegesGrantedAccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no errors, received an error \"%v\"", err)
 	} else if !reflect.DeepEqual(expectedAccess, receivedAccess) {
-		t.Errorf(`Expected user access and received user access are note the same.
+		t.Errorf(`Expected user access and received user access are not the same.
         Expected: %v
         Received: %v`, expectedAccess, receivedAccess)
 	}
@@ -269,7 +269,7 @@ func TestCheckPrivilegesGrantedAccessAuthz(t *testing.T) {
 		t.Errorf("Expected no errors, received an error \"%v\"", err)
 		// don't use DeepEqual since expectedAccess is []interface {} and receivedAccess is []map[string]interface {}, just check for contents
 	} else if fmt.Sprint(expectedAccess) != fmt.Sprint(receivedAccess) {
-		t.Errorf(`Expected user access and received user access are note the same.
+		t.Errorf(`Expected user access and received user access are not the same.
         Expected: %v
         Received: %v`, expectedAccess, receivedAccess)
 	}

--- a/tests/functions_test.go
+++ b/tests/functions_test.go
@@ -45,14 +45,14 @@ func TestDoRequestWithSignedHeaderGoodToken(t *testing.T) {
 	mockRequest := mocks.NewMockRequestInterface(mockCtrl)
 	testFunction := &jwt.Functions{Config: mockConfig, Request: mockRequest}
 
-	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_exprired_token", APIEndpoint: "http://www.test.com"}
+	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_expired_token", APIEndpoint: "http://www.test.com"}
 	mockedResp := &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewBufferString("{\"url\": \"http://www.test.com/user/data/download/test_uuid\"}")),
 		StatusCode: 200,
 	}
 
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
-	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/data/download/test_uuid", "non_exprired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
+	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/data/download/test_uuid", "non_expired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
 
 	_, err := testFunction.DoRequestWithSignedHeader("default", "", "/user/data/download/test_uuid", "", nil)
 
@@ -148,14 +148,14 @@ func TestCheckPrivilegesNoAccess(t *testing.T) {
 	mockRequest := mocks.NewMockRequestInterface(mockCtrl)
 	testFunction := &jwt.Functions{Config: mockConfig, Request: mockRequest}
 
-	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_exprired_token", APIEndpoint: "http://www.test.com"}
+	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_expired_token", APIEndpoint: "http://www.test.com"}
 	mockedResp := &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewBufferString("{\"project_access\": {}}")),
 		StatusCode: 200,
 	}
 
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
-	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_exprired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
+	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_expired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
 
 	_, receivedAccess, err := testFunction.CheckPrivileges("default", "")
 
@@ -177,16 +177,14 @@ func TestCheckPrivilegesGrantedAccess(t *testing.T) {
 	mockRequest := mocks.NewMockRequestInterface(mockCtrl)
 	testFunction := &jwt.Functions{Config: mockConfig, Request: mockRequest}
 
-	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_exprired_token", APIEndpoint: "http://www.test.com"}
+	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_expired_token", APIEndpoint: "http://www.test.com"}
 
-	grantedAccessJSON := "{\"project_access\": " +
-		"{\"test_project\": [" +
-		"\"read\"," +
-		"\"create\"," +
-		"\"read-storage\"," +
-		"\"update\"," +
-		"\"delete\"]}" +
-		"}"
+	grantedAccessJSON := `{
+		"project_access":
+			{
+				"test_project": ["read", "create","read-storage","update","delete"]
+			}
+		}`
 
 	mockedResp := &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewBufferString(grantedAccessJSON)),
@@ -194,7 +192,7 @@ func TestCheckPrivilegesGrantedAccess(t *testing.T) {
 	}
 
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
-	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_exprired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
+	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_expired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
 
 	_, expectedAccess, err := testFunction.CheckPrivileges("default", "")
 
@@ -225,25 +223,23 @@ func TestCheckPrivilegesGrantedAccessAuthz(t *testing.T) {
 	mockRequest := mocks.NewMockRequestInterface(mockCtrl)
 	testFunction := &jwt.Functions{Config: mockConfig, Request: mockRequest}
 
-	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_exprired_token", APIEndpoint: "http://www.test.com"}
+	cred := jwt.Credential{KeyId: "", APIKey: "fake_api_key", AccessKey: "non_expired_token", APIEndpoint: "http://www.test.com"}
 
-	grantedAccessJSON := "{\"authz\": " +
-		"{\"test_project\":[" +
-		"{\"method\":\"create\",\"service\":\"*\"}," +
-		"{\"method\":\"delete\",\"service\":\"*\"}," +
-		"{\"method\":\"read\",\"service\":\"*\"}," +
-		"{\"method\":\"read-storage\",\"service\":\"*\"}," +
-		"{\"method\":\"update\",\"service\":\"*\"}," +
-		"{\"method\":\"upload\",\"service\":\"*\"}" +
-		"]}," +
-		"\"project_access\": " +
-		"{\"test_project\": [" +
-		"\"read\"," +
-		"\"create\"," +
-		"\"read-storage\"," +
-		"\"update\"," +
-		"\"delete\"]}" +
-		"}"
+	grantedAccessJSON := `{
+		"authz": {
+			"test_project":[
+				{"method":"create", "service":"*"},
+				{"method":"delete", "service":"*"},
+				{"method":"read", "service":"*"},
+				{"method":"read-storage", "service":"*"},
+				{"method":"update", "service":"*"},
+				{"method":"upload", "service":"*"}
+			]
+		},
+		"project_access": {
+			"test_project": ["read", "create","read-storage","update","delete"]
+		}
+	}`
 
 	mockedResp := &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewBufferString(grantedAccessJSON)),
@@ -251,7 +247,7 @@ func TestCheckPrivilegesGrantedAccessAuthz(t *testing.T) {
 	}
 
 	mockConfig.EXPECT().ParseConfig("default").Return(cred).Times(1)
-	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_exprired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
+	mockRequest.EXPECT().MakeARequest("GET", "http://www.test.com/user/user", "non_expired_token", "", gomock.Any(), gomock.Any()).Return(mockedResp, nil).Times(1)
 
 	_, expectedAccess, err := testFunction.CheckPrivileges("default", "")
 


### PR DESCRIPTION
Jira Ticket: [PXP-6106](https://ctds-planx.atlassian.net/browse/PXP-6106)

`auth` command will checks for `authz` section (Arborist premissions) first, and fallback to check for `project_access` section (Fence premissions) if `authz` section is empty or missing

```
➜  bin ./gen3-client auth --profile=mshao_qa-mickey
2021/03/02 11:21:17 
You have access to the following resource(s) at https://qa-mickey.planx-pla.net:
2021/03/02 11:21:17 /dashboard [
  {
    "method": "access",
    "service": "dashboard"
  }
]
2021/03/02 11:21:17 /data_file [
  {
    "method": "file_upload",
    "service": "fence"
  }
]
2021/03/02 11:21:17 /gen3/programs/DEV [
  {
    "method": "create",
    "service": "*"
  },
  {
    "method": "delete",
    "service": "*"
  },
  {
    "method": "read",
    "service": "*"
  },
  {
    "method": "read-storage",
    "service": "*"
  },
  {
    "method": "update",
    "service": "*"
  }
]
...
```


### Improvements
- `auth` command will checks for `authz` section (Arborist premissions) first, and fallback to check for `project_access` section (Fence premissions) if `authz` section is empty or missing

