### PR TITLE
Commenting Replacing dots with slashes logic

### DIFF
--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -472,7 +472,6 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 		dir, file := filepath.Split(subFilename)
 		if dir != "" && dir != commonUtils.PathSeparator {
 			filename = strings.TrimPrefix(subFilename, commonUtils.PathSeparator)
-			//filename = strings.Replace(filename, commonUtils.PathSeparator, ".", -1)
 			filename = filepath.ToSlash(filename)
 		} else {
 			filename = file

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -472,7 +472,8 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 		dir, file := filepath.Split(subFilename)
 		if dir != "" && dir != commonUtils.PathSeparator {
 			filename = strings.TrimPrefix(subFilename, commonUtils.PathSeparator)
-			filename = strings.Replace(filename, commonUtils.PathSeparator, ".", -1)
+			//filename = strings.Replace(filename, commonUtils.PathSeparator, ".", -1)
+			filename = filepath.ToSlash(filename)
 		} else {
 			filename = file
 		}


### PR DESCRIPTION
Jira Ticket: PXP-7648
This change will replace dots(.) with slashes in the filenames of the index records. Using gen3-client upload command with the "--include-subdirname" option, the slashes (“.”) are replaced with dots (“/”) in the file_name field of indexd.


### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
