### PR TITLE
PXP-8703 Updated process filename logic

### DIFF
--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -467,7 +467,22 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 	var metadata commonUtils.FileMetadata
 	if includeSubDirName {
 		uploadPath, err = commonUtils.GetAbsolutePath(uploadPath)
-		presentDirname := strings.TrimSuffix(uploadPath, commonUtils.PathSeparator+"*")
+
+		var presentDirname string
+		if err == nil {
+			fileInfo, err := os.Stat(uploadPath)
+			if os.IsNotExist(err) {
+				fmt.Println("uploadpath is not valid")
+			}
+			if !fileInfo.IsDir() {
+				_, file := filepath.Split(uploadPath)
+				presentDirname = strings.TrimSuffix(uploadPath, file)
+
+			} else {
+				presentDirname = strings.TrimSuffix(uploadPath, commonUtils.PathSeparator+"*")
+
+			}
+		}
 		subFilename := strings.TrimPrefix(filePath, presentDirname)
 		dir, file := filepath.Split(subFilename)
 		if dir != "" && dir != commonUtils.PathSeparator {

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -475,12 +475,11 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 				fmt.Println("uploadpath is not valid")
 			}
 			if !fileInfo.IsDir() {
-				_, file := filepath.Split(uploadPath)
-				presentDirname = strings.TrimSuffix(uploadPath, file)
+				presentDirname, _ = filepath.Split(uploadPath)
 
-			} else {
+			}
+			if fileInfo.IsDir() {
 				presentDirname = strings.TrimSuffix(uploadPath, commonUtils.PathSeparator+"*")
-
 			}
 		}
 		subFilename := strings.TrimPrefix(filePath, presentDirname)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -474,7 +474,11 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 				log.Fatal(err)
 			}
 			if !fileInfo.IsDir() {
-				filename = presentPath
+				pwd, err := os.Getwd()
+				if err != nil {
+					log.Fatal(err)
+				}
+				filename = strings.TrimPrefix(presentPath, pwd)
 
 			} else {
 				filename = strings.TrimPrefix(filePath, presentPath)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -482,8 +482,8 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 
 			} else {
 				filename = strings.TrimPrefix(filePath, presentPath)
-				filename = strings.TrimPrefix(filename, commonUtils.PathSeparator)
 			}
+			filename = strings.TrimPrefix(filename, commonUtils.PathSeparator)
 		}
 	}
 	if includeMetadata {

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -474,7 +474,8 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 				log.Fatal(err)
 			}
 			if !fileInfo.IsDir() {
-				// do nothing (explicitly)
+				filename = presentPath
+
 			} else {
 				filename = strings.TrimPrefix(filePath, presentPath)
 				filename = strings.TrimPrefix(filename, commonUtils.PathSeparator)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -466,20 +466,22 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 	filename := filepath.Base(filePath)
 	var metadata commonUtils.FileMetadata
 	if includeSubDirName {
-		uploadPath, err = commonUtils.GetAbsolutePath(uploadPath)
-
+		uploadPath, err := commonUtils.GetAbsolutePath(uploadPath)
 		var presentDirname string
 		if err == nil {
 			fileInfo, err := os.Stat(uploadPath)
 			if os.IsNotExist(err) {
-				fmt.Println("uploadpath is not valid")
-			}
-			if !fileInfo.IsDir() {
-				presentDirname, _ = filepath.Split(uploadPath)
-
+				log.Fatal(err)
 			}
 			if fileInfo.IsDir() {
 				presentDirname = strings.TrimSuffix(uploadPath, commonUtils.PathSeparator+"*")
+
+			} else {
+				pwd, err := os.Getwd()
+				if err != nil {
+					log.Fatal(err)
+				}
+				presentDirname = pwd
 			}
 		}
 		subFilename := strings.TrimPrefix(filePath, presentDirname)

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -467,30 +467,18 @@ func ProcessFilename(uploadPath string, filePath string, includeSubDirName bool,
 	var metadata commonUtils.FileMetadata
 	if includeSubDirName {
 		uploadPath, err := commonUtils.GetAbsolutePath(uploadPath)
-		var presentDirname string
 		if err == nil {
-			fileInfo, err := os.Stat(uploadPath)
-			if os.IsNotExist(err) {
+			presentPath := strings.TrimSuffix(uploadPath, commonUtils.PathSeparator+"*")
+			fileInfo, err := os.Stat(presentPath)
+			if err != nil {
 				log.Fatal(err)
 			}
-			if fileInfo.IsDir() {
-				presentDirname = strings.TrimSuffix(uploadPath, commonUtils.PathSeparator+"*")
-
+			if !fileInfo.IsDir() {
+				// do nothing (explicitly)
 			} else {
-				pwd, err := os.Getwd()
-				if err != nil {
-					log.Fatal(err)
-				}
-				presentDirname = pwd
+				filename = strings.TrimPrefix(filePath, presentPath)
+				filename = strings.TrimPrefix(filename, commonUtils.PathSeparator)
 			}
-		}
-		subFilename := strings.TrimPrefix(filePath, presentDirname)
-		dir, file := filepath.Split(subFilename)
-		if dir != "" && dir != commonUtils.PathSeparator {
-			filename = strings.TrimPrefix(subFilename, commonUtils.PathSeparator)
-			filename = filepath.ToSlash(filename)
-		} else {
-			filename = file
 		}
 	}
 	if includeMetadata {


### PR DESCRIPTION
When a file is uploaded using gen3-client with --include-subdirectory flag on then the filename is empty from indexd record. 

for example: 
- ./gen3-client upload --profile=ramudev --include-subdirname=true --upload-path=/Users/ramunerella/Desktop/test [filename is not empty]
- ./gen3-client upload --profile=ramudev --include-subdirname=true --upload-path=/Users/ramunerella/Desktop/test/test_subfolder/test020.dcm [filename is empty]

- Updated process filename logic


### New Features


### Breaking Changes


### Bug Fixes
Updated filename name logic when 'includesubdir' flag is on.

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
