### PR TITLE
Cache config so we don't read the config file more than once

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-06-12T01:22:58Z",
+  "generated_at": "2021-10-20T16:36:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -114,25 +114,25 @@
       {
         "hashed_secret": "2ace62c1befa19e3ea37dd52be9f6d508c5163e6",
         "is_verified": false,
-        "line_number": 174,
+        "line_number": 176,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "4c85e7c51e03e596b7e4f1d78d30c4fce2ee1df4",
         "is_verified": false,
-        "line_number": 208,
+        "line_number": 216,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "a72b75fddaf62834933122c3ff0d5b1aab840719",
         "is_verified": false,
-        "line_number": 216,
+        "line_number": 224,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_verified": false,
-        "line_number": 234,
+        "line_number": 252,
         "type": "Secret Keyword"
       }
     ],


### PR DESCRIPTION
### Improvements
- Cache the credentials configuration so we don't read the configuration file more than once

### Bug Fixes
- Fix error when the configuration does not include shepherd fields