### PR TITLE
Log errors earlier

### DIFF
--- a/gen3-client/g3cmd/download-multiple.go
+++ b/gen3-client/g3cmd/download-multiple.go
@@ -211,6 +211,7 @@ func batchDownload(g3 Gen3Interface, batchFDRSlice []commonUtils.FileDownloadRes
 	for _, fdrObject := range batchFDRSlice {
 		err := GetDownloadResponse(g3, profile, &fdrObject, protocolText)
 		if err != nil {
+			log.Println(err.Error())
 			errCh <- err
 			continue
 		}
@@ -228,7 +229,9 @@ func batchDownload(g3 Gen3Interface, batchFDRSlice []commonUtils.FileDownloadRes
 		}
 		file, err := os.OpenFile(fdrObject.DownloadPath+fdrObject.Filename, fileFlag, 0666)
 		if err != nil {
-			errCh <- errors.New("Error occurred during opening local file: " + err.Error())
+			err_msg := errors.New("Error occurred during opening local file: " + err.Error())
+			log.Println(err_msg)
+			errCh <- err_msg
 			continue
 		}
 		defer file.Close()
@@ -244,7 +247,9 @@ func batchDownload(g3 Gen3Interface, batchFDRSlice []commonUtils.FileDownloadRes
 	fdrCh := make(chan commonUtils.FileDownloadResponseObject, len(fdrs))
 	pool, err := pb.StartPool(bars...)
 	if err != nil {
-		errCh <- errors.New("Error occurred during initializing progress bars: " + err.Error())
+		err_msg := errors.New("Error occurred during initializing progress bars: " + err.Error())
+		log.Println(err_msg)
+		errCh <- err_msg
 		return 0
 	}
 
@@ -255,7 +260,9 @@ func batchDownload(g3 Gen3Interface, batchFDRSlice []commonUtils.FileDownloadRes
 		go func() {
 			for fdr := range fdrCh {
 				if _, err = io.Copy(fdr.Writer, fdr.Response.Body); err != nil {
-					errCh <- errors.New("io.Copy error: " + err.Error())
+					err_msg := errors.New("io.Copy error: " + err.Error())
+					log.Println(err_msg)
+					errCh <- err_msg
 					return
 				}
 				succeeded++

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -511,7 +511,7 @@ func getFullFilePath(filePath string, filename string) (string, error) {
 	filePath, err := commonUtils.GetAbsolutePath(filePath)
 	fi, err := os.Stat(filePath)
 	if err != nil {
-		log.Println(err)
+		log.Println(err.Error())
 		return "", err
 	}
 	switch mode := fi.Mode(); {
@@ -619,6 +619,7 @@ func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploa
 			respURL, guid, err = GeneratePresignedURL(gen3Interface, profile, furObjects[i].Filename, furObjects[i].FileMetadata)
 			if err != nil {
 				logs.AddToFailedLog(furObjects[i].FilePath, furObjects[i].Filename, furObjects[i].FileMetadata, guid, 0, false, true)
+				log.Println(err.Error())
 				errCh <- err
 				continue
 			}
@@ -630,7 +631,9 @@ func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploa
 		file, err := os.Open(furObjects[i].FilePath)
 		if err != nil {
 			logs.AddToFailedLog(furObjects[i].FilePath, furObjects[i].Filename, furObjects[i].FileMetadata, furObjects[i].GUID, 0, false, true)
-			errCh <- errors.New("File open error: " + err.Error())
+			err_msg := errors.New("File open error: " + err.Error())
+			log.Println(err_msg)
+			errCh <- err_msg
 			continue
 		}
 		defer file.Close()
@@ -639,7 +642,9 @@ func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploa
 		if err != nil {
 			file.Close()
 			logs.AddToFailedLog(furObjects[i].FilePath, furObjects[i].Filename, furObjects[i].FileMetadata, furObjects[i].GUID, 0, false, true)
-			errCh <- errors.New("Error occurred during request generation: " + err.Error())
+			err_msg := errors.New("Error occurred during request generation: " + err.Error())
+			log.Println(err_msg)
+			errCh <- err_msg
 			continue
 		}
 		bars = append(bars, furObjects[i].Bar)
@@ -652,7 +657,9 @@ func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploa
 		for _, furObject := range furObjects {
 			logs.AddToFailedLog(furObject.FilePath, furObject.Filename, furObject.FileMetadata, furObject.GUID, 0, false, true)
 		}
-		errCh <- errors.New("Error occurred during starting progress bar pool: " + err.Error())
+		err_msg := errors.New("Error occurred during starting progress bar pool: " + err.Error())
+		log.Println(err_msg)
+		errCh <- err_msg
 		return
 	}
 
@@ -666,6 +673,7 @@ func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploa
 					resp, err := client.Do(furObject.Request)
 					if err != nil {
 						logs.AddToFailedLog(furObject.FilePath, furObject.Filename, furObject.FileMetadata, furObject.GUID, 0, false, true)
+						log.Println(err.Error())
 						errCh <- err
 					} else {
 						if resp.StatusCode != 200 {

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -120,7 +120,7 @@ func (f *Functions) ParseFenceURLResponse(resp *http.Response) (JsonMessage, err
 	if !(resp.StatusCode == 200 || resp.StatusCode == 201) {
 		switch resp.StatusCode {
 		case 401:
-			return msg, errors.New("401 Unauthorized error has occurred! Something went wrong during authentication, please check your configuration and/or credentials")
+			return msg, errors.New("401 Unauthorized error has occurred! Something went wrong during authentication, please check your access, configuration and/or credentials")
 		case 403:
 			return msg, errors.New("403 Forbidden error has occurred! You don't have permission to access the requested url \"" + resp.Request.URL.String() + "\"")
 		case 404:


### PR DESCRIPTION


### Improvements
- Log `download-multiple` errors earlier, in addition to logging all errors at the end
