### PR TITLE
feat(version_check): enable version check bypass

### DIFF
--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -54,7 +54,8 @@ func initConfig() {
 	}
 
 	// version checker
-	if gitversion != "" && gitversion != "N/A" {
+	if os.Getenv("GEN3_CLIENT_VERSION_CHECK") != "false" &&
+	gitversion != "" && gitversion != "N/A" {
 		githubTag := &latest.GithubTag{
 			Owner:      "uc-cdis",
 			Repository: "cdis-data-client",


### PR DESCRIPTION
### New Features
Added a conditional environment variable `GEN3_CLIENT_VERSION_CHECK` to allow bypassing client version checks, this is a workaround for users when experiencing issues with github API rate limits due to multiple sequential calls.

### Breaking Changes
None

### Bug Fixes
None

### Improvements
None

### Dependency updates
None

### Deployment changes
None