### PR TITLE
Improve error message when Fence upload returns 404

### DIFF
--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -335,7 +335,7 @@ func GeneratePresignedURL(g3 Gen3Interface, filename string, fileMetadata common
 	msg, err := g3.DoRequestWithSignedHeader(&profileConfig, commonUtils.FenceDataUploadEndpoint, "application/json", objectBytes)
 
 	if err != nil {
-		return "", "", errors.New("You don't have permission to upload data, detailed error message: " + err.Error())
+		return "", "", errors.New("Something went wrong. Maybe you don't have permission to upload data or Fence is misconfigured. Detailed error message: " + err.Error())
 	}
 	if msg.URL == "" || msg.GUID == "" {
 		return "", "", errors.New("Unknown error has occurred during presigned URL or GUID generation. Please check logs from Gen3 services")

--- a/gen3-client/jwt/functions.go
+++ b/gen3-client/jwt/functions.go
@@ -131,7 +131,7 @@ func (f *Functions) ParseFenceURLResponse(resp *http.Response) (JsonMessage, err
 		case 403:
 			return msg, errors.New("403 Forbidden error has occurred! You don't have permission to access the requested url \"" + resp.Request.URL.String() + "\"")
 		case 404:
-			return msg, errors.New("404 Not found error has occurred! The requested url \"" + resp.Request.URL.String() + "\" cannot be found")
+			return msg, errors.New("404 Not found error has occurred! The requested url \"" + resp.Request.URL.String() + "\" cannot be found or one of the requested resources cannot be found")
 		case 500:
 			return msg, errors.New("500 Internal Server error has occurred! Please try again later")
 		case 503:


### PR DESCRIPTION
When the data upload is misconfigured, Fence may return a 404. Currently the client always interprets this as "URL not found" which is not always accurate. The client also wrongly suggests that the user does not have access.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Improve error message when Fence upload returns 404

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
