### PR TITLE
Update initial support for specifying data bucket

### DIFF
--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -115,7 +115,7 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject) {
 				}
 			}
 		} else {
-			presignedURL, guid, err = GeneratePresignedURL(gen3Interface, ro.Filename, ro.FileMetadata)
+			presignedURL, guid, err = GeneratePresignedURL(gen3Interface, ro.Filename, ro.FileMetadata, bucketPtr)
 			if err != nil {
 				updateRetryObject(&ro, ro.FilePath, ro.Filename, ro.FileMetadata, guid, ro.RetryCount, false)
 				handleFailedRetry(ro, retryObjCh, err, true)

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -17,6 +17,7 @@ import (
 )
 
 func init() {
+	var bucketName string
 	var manifestPath string
 	var uploadPath string
 	var batch bool
@@ -87,12 +88,12 @@ func init() {
 					if len(batchFURObjects) < workers {
 						batchFURObjects = append(batchFURObjects, furObject)
 					} else {
-						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh)
+						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh, bucketName)
 						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
 						batchFURObjects = append(batchFURObjects, furObject)
 					}
 					if i == len(furObjects)-1 { // upload remainders
-						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh)
+						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh, bucketName)
 					}
 				} else {
 					file, err := os.Open(furObject.FilePath)
@@ -135,5 +136,6 @@ func init() {
 	uploadMultipleCmd.MarkFlagRequired("upload-path") //nolint:errcheck
 	uploadMultipleCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")
 	uploadMultipleCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
+	uploadMultipleCmd.Flags().StringVar(&bucketName, "bucket", "", "The bucket to which files will be uploaded")
 	RootCmd.AddCommand(uploadMultipleCmd)
 }

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -86,13 +86,13 @@ func init() {
 						furObject := commonUtils.FileUploadRequestObject{FilePath: fileInfo.FilePath, Filename: fileInfo.Filename, FileMetadata: fileInfo.FileMetadata, GUID: ""}
 						batchFURObjects = append(batchFURObjects, furObject)
 					} else {
-						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh)
+						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh, bucketName)
 						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
 						furObject := commonUtils.FileUploadRequestObject{FilePath: fileInfo.FilePath, Filename: fileInfo.Filename, FileMetadata: fileInfo.FileMetadata, GUID: ""}
 						batchFURObjects = append(batchFURObjects, furObject)
 					}
 				}
-				batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh)
+				batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh, bucketName)
 
 				if len(errCh) > 0 {
 					close(errCh)
@@ -124,7 +124,7 @@ func init() {
 						continue
 					}
 					// The following flow is for singlepart upload flow
-					respURL, guid, err := GeneratePresignedURL(gen3Interface, fileInfo.Filename, fileInfo.FileMetadata)
+					respURL, guid, err := GeneratePresignedURL(gen3Interface, fileInfo.Filename, fileInfo.FileMetadata, bucketName)
 					if err != nil {
 						logs.AddToFailedLog(fileInfo.FilePath, fileInfo.Filename, fileInfo.FileMetadata, guid, 0, false, true)
 						log.Println(err.Error())

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -294,7 +294,7 @@ func sanitizeErrorMsg(errorMsg string, sensitiveURL string) string {
 }
 
 // GeneratePresignedURL helps sending requests to Shepherd/Fence and parsing the response in order to get presigned URL for the new upload flow
-func GeneratePresignedURL(g3 Gen3Interface, filename string, fileMetadata commonUtils.FileMetadata) (string, string, error) {
+func GeneratePresignedURL(g3 Gen3Interface, filename string, fileMetadata commonUtils.FileMetadata, bucketName string) (string, string, error) {
 	// Attempt to get the presigned URL of this file from Shepherd if it's deployed, otherwise fall back to Fence.
 	hasShepherd, err := g3.CheckForShepherdAPI(&profileConfig)
 	if err != nil {
@@ -344,7 +344,7 @@ func GeneratePresignedURL(g3 Gen3Interface, filename string, fileMetadata common
 	}
 
 	// Otherwise, fall back to Fence
-	purObject := InitRequestObject{Filename: filename}
+	purObject := InitRequestObject{Filename: filename, Bucket: &bucketName}
 	objectBytes, err := json.Marshal(purObject)
 	if err != nil {
 		return "", "", errors.New("Error occurred when marshalling object: " + err.Error())
@@ -626,7 +626,7 @@ func initBatchUploadChannels(numParallel int, inputSliceLen int) (int, chan *htt
 	return workers, respCh, errCh, batchFURSlice
 }
 
-func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploadRequestObject, workers int, respCh chan *http.Response, errCh chan error) {
+func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploadRequestObject, workers int, respCh chan *http.Response, errCh chan error, bucketName string) {
 	bars := make([]*pb.ProgressBar, 0)
 	respURL := ""
 	var err error
@@ -634,7 +634,7 @@ func batchUpload(gen3Interface Gen3Interface, furObjects []commonUtils.FileUploa
 
 	for i := range furObjects {
 		if furObjects[i].GUID == "" {
-			respURL, guid, err = GeneratePresignedURL(gen3Interface, furObjects[i].Filename, furObjects[i].FileMetadata)
+			respURL, guid, err = GeneratePresignedURL(gen3Interface, furObjects[i].Filename, furObjects[i].FileMetadata, bucketName)
 			if err != nil {
 				logs.AddToFailedLog(furObjects[i].FilePath, furObjects[i].Filename, furObjects[i].FileMetadata, guid, 0, false, true)
 				errCh <- err

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -145,6 +145,7 @@ func TestGeneratePresignedURL_noShepherd(t *testing.T) {
 		Profile: "test-profile",
 	}
 	testFilename := "test-file"
+	testBucketname := "test-bucket"
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -156,7 +157,7 @@ func TestGeneratePresignedURL_noShepherd(t *testing.T) {
 		Return(false, nil)
 
 	// Mock the request to Fence's data upload endpoint to create a presigned url for this file name.
-	expectedReqBody := []byte(fmt.Sprintf(`{"file_name":"%v"}`, testFilename))
+	expectedReqBody := []byte(fmt.Sprintf(`{"file_name":"%v","bucket":"%v"}`, testFilename, testBucketname))
 	mockPresignedURL := "https://example.com/example.pfb"
 	mockGUID := "000000-0000000-0000000-000000"
 	mockUploadURLResponse := jwt.JsonMessage{
@@ -169,7 +170,7 @@ func TestGeneratePresignedURL_noShepherd(t *testing.T) {
 		Return(mockUploadURLResponse, nil)
 	// ----------
 
-	url, guid, err := g3cmd.GeneratePresignedURL(mockGen3Interface, testFilename, commonUtils.FileMetadata{})
+	url, guid, err := g3cmd.GeneratePresignedURL(mockGen3Interface, testFilename, commonUtils.FileMetadata{}, testBucketname)
 	if err != nil {
 		t.Error(err)
 	}
@@ -190,6 +191,7 @@ func TestGeneratePresignedURL_withShepherd(t *testing.T) {
 		Profile: "test-profile",
 	}
 	testFilename := "test-file"
+	testBucketname := "test-bucket"
 	testMetadata := commonUtils.FileMetadata{
 		Aliases:  []string{"test-alias-1", "test-alias-2"},
 		Authz:    []string{"authz-resource-1", "authz-resource-2"},
@@ -238,7 +240,7 @@ func TestGeneratePresignedURL_withShepherd(t *testing.T) {
 		Return("", &mockUploadURLResponse, nil)
 	// ----------
 
-	url, guid, err := g3cmd.GeneratePresignedURL(mockGen3Interface, testFilename, testMetadata)
+	url, guid, err := g3cmd.GeneratePresignedURL(mockGen3Interface, testFilename, testMetadata, testBucketname)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
### New Features

- Add data bucket flag for single part upload using @nss10's [add_bucket_name branch](https://github.com/uc-cdis/cdis-data-client/compare/master...feat/add_bucket_name)
- Add `bucketname` to Fence calls in tests 

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
