### PR TITLE
Use file_name provided in manifest

### DIFF
--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -535,8 +535,13 @@ func validateObject(objects []ManifestObject, uploadPath string) []commonUtils.F
 	furObjects := make([]commonUtils.FileUploadRequestObject, 0)
 	for _, object := range objects {
 		guid := object.ObjectID
-		// Here we are assuming the local filename will be the same as GUID
-		filePath, err := getFullFilePath(uploadPath, object.ObjectID)
+		// use file_name if it is set
+		var fileName = object.Filename
+		if object.Filename == "" {
+			// Otherwise, here we are assuming the local filename will be the same as GUID
+			fileName = object.ObjectID
+		}
+		filePath, err := getFullFilePath(uploadPath, fileName)
 		if err != nil {
 			log.Println(err.Error())
 			continue


### PR DESCRIPTION
This PR improves usability by reading the file name from the manifest used by `upload-multiple` and `upload-single`.

Currently, as written, the `validateObject` method assumes that the local file name on the submitter's system is equal to the ObjectID in the manifest.  This forces the submitter to name all the files on their local system to a guid?

This PR uses the `file_name` attribute, already defined in the manifest.  If populated, it will be used in the path.