### PR TITLE
Add Param to not create blank records for upload

### DIFF
--- a/gen3-client/commonUtils/commonUtils.go
+++ b/gen3-client/commonUtils/commonUtils.go
@@ -107,6 +107,8 @@ type RetryObject struct {
 	RetryCount   int
 	Multipart    bool
 	Bucket 		 string
+	fileNameToIDMap	 map[string]string
+	CreateRecord bool
 }
 
 // ParseRootPath parses dirname that has "~" in the beginning

--- a/gen3-client/g3cmd/retry-upload.go
+++ b/gen3-client/g3cmd/retry-upload.go
@@ -97,7 +97,7 @@ func retryUpload(failedLogMap map[string]commonUtils.RetryObject) {
 
 		if ro.Multipart {
 			fileInfo := FileInfo{FilePath: ro.FilePath, Filename: ro.Filename}
-			err = multipartUpload(gen3Interface, fileInfo, ro.RetryCount, ro.Bucket)
+			err = multipartUpload(gen3Interface, fileInfo, ro.RetryCount, ro.Bucket, ro.fileNameToIDMap, ro.CreateRecord)
 			if err != nil {
 				updateRetryObject(&ro, ro.FilePath, ro.Filename, ro.FileMetadata, ro.GUID, ro.RetryCount, true)
 				handleFailedRetry(ro, retryObjCh, err, true)

--- a/gen3-client/g3cmd/upload-multipart.go
+++ b/gen3-client/g3cmd/upload-multipart.go
@@ -37,7 +37,7 @@ func retry(attempts int, filePath string, guid string, f func() error) (err erro
 	return fmt.Errorf("After %d attempts, last error: %s", attempts, err)
 }
 
-func multipartUpload(g3 Gen3Interface, fileInfo FileInfo, retryCount int, bucketName string) error {
+func multipartUpload(g3 Gen3Interface, fileInfo FileInfo, retryCount int, bucketName string, fileNameToIDMap map[string]string, createRecord bool) error {
 	// NOTE @mpingram -- multipartUpload does not yet use the new Shepherd API
 	// because Shepherd does not yet support multipart uploads.
 	file, err := os.Open(fileInfo.FilePath)
@@ -61,7 +61,7 @@ func multipartUpload(g3 Gen3Interface, fileInfo FileInfo, retryCount int, bucket
 		return err
 	}
 
-	uploadID, guid, err := InitMultipartUpload(g3, fileInfo.Filename, bucketName)
+	uploadID, guid, err := InitMultipartUpload(g3, fileInfo.Filename, bucketName, fileNameToIDMap, createRecord)
 	if err != nil {
 		logs.AddToFailedLog(fileInfo.FilePath, fileInfo.Filename, fileInfo.FileMetadata, guid, retryCount, true, true)
 		err = fmt.Errorf("FAILED multipart upload for %s: %s", fileInfo.Filename, err.Error())

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -154,7 +154,7 @@ func init() {
 			if len(multipartFilePaths) > 0 {
 				// NOTE(@mpingram) - For the moment Shepherd doesn't support multipart uploads.
 				// Throw an error if Shepherd is enabled and user attempts to multipart upload.
-				processMultipartUpload(gen3Interface, multipartFilePaths, bucketName, includeSubDirName, uploadPath)
+				processMultipartUpload(gen3Interface, multipartFilePaths, bucketName, includeSubDirName, uploadPath, nil, false)
 			}
 
 			if !logs.IsFailedLogMapEmpty() {

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -39,6 +39,8 @@ type ManifestObject struct {
 type InitRequestObject struct {
 	Filename string `json:"file_name"`
 	Bucket 	 string `json:"bucket,omitempty"`
+	ObjectID string `json:"did,omitempty"`
+	CreateRecord bool `json:"create_record,omitempty"`
 }
 
 // ShepherdInitRequestObject represents the payload that sends to Shepherd for getting a singlepart upload presignedURL or init a multipart upload for new object file
@@ -124,9 +126,16 @@ const MaxRetryCount = 5
 const maxWaitTime = 300
 
 // InitMultipartUpload helps sending requests to FENCE to init a multipart upload
-func InitMultipartUpload(g3 Gen3Interface, filename string, bucketName string) (string, string, error) {
-	multipartInitObject := InitRequestObject{Filename: filename, Bucket: bucketName}
+func InitMultipartUpload(g3 Gen3Interface, filename string, bucketName string, fileNameToIDMap map[string]string, createRecord bool) (string, string, error) {
+	var did string
+	log.Println(fileNameToIDMap)
+	if fileNameToIDMap != nil{
+		did = fileNameToIDMap[filename]
+	}
+	multipartInitObject := InitRequestObject{Filename: filename, Bucket: bucketName, ObjectID:did, CreateRecord:createRecord}
 	objectBytes, err := json.Marshal(multipartInitObject)
+	log.Println(multipartInitObject)
+
 	if err != nil {
 		return "", "", errors.New("Error has occurred during marshalling data for multipart upload initialization, detailed error message: " + err.Error())
 	}


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features
- add `create_record` parameter in `upload-multiple` command. Option to not create a blank record in indexd when trying to multi-part upload.  

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
