### PR TITLE
Use GUID for multiple uploads if provided in file manifest

### DIFF
--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -122,6 +122,10 @@ func init() {
 					}
 					if len(batchFURObjects) < workers {
 						furObject := commonUtils.FileUploadRequestObject{FilePath: fileInfo.FilePath, Filename: fileInfo.Filename, FileMetadata: fileInfo.FileMetadata, GUID: ""}
+						// If objectID/GUID is found in the map, assign it to the furObject
+						if objectID, ok := fileNameToIDMap[fileInfo.Filename]; ok {
+							furObject.GUID = objectID
+						}
 						batchFURObjects = append(batchFURObjects, furObject) //nolint:ineffassign
 					} else {
 						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh, bucketName, fileNameToIDMap)


### PR DESCRIPTION
# Overview

Small update to use GUIDs if provided in the file manifest, rather than making an additional [call to Fence](https://github.com/ACED-IDP/cdis-data-client/blob/53f924a837f3836fced95c507493c97638cc8c64/gen3-client/g3cmd/utils.go#L623-L634).

# Current Behavior

## Uploading File ⚠️

Running the the following command results in the `gen3-client` making a [call to Fence](https://github.com/ACED-IDP/cdis-data-client/blob/53f924a837f3836fced95c507493c97638cc8c64/gen3-client/g3cmd/utils.go#L623-L634) to generate a GUID for the presigned URL during file upload:

The file is then uploaded to a URL with a path that doesn't match that in the Indexd database. The file appears to be uploaded to the Gen3 system successfully, but the user encounters a `404` error when attempting to download the file.

```sh
➜ cat example.txt
Example Data

➜ cat manifest.json
[
  {
    "object_id": "000d0430-e8dc-526b-a2f6-165ab7b9f2f2",   # <--- File GUID
    "md5": "e0c38194dbc33fd1af874f027e270c83", 
    "file_name": "example.txt",
    "size": 13
  }
]

➜ gen3-client upload-multiple --profile=local --manifest=manifest.json --upload-path=. --bucket example-bucket
# Notice: this is the upload method which requires the user to provide GUIDs. In this method files will be uploaded to specified GUIDs.
# If your intention is to upload files without pre-existing GUIDs, consider to use "./gen3-client upload" instead.
# 
# 2024/06/07 18:00:41 Filename to ID map found. Attempting to upload to existing Indexd records using Fence...
# example.txt  13 B / 13 B [=======================================] 100.00%
# 
# Submission Results
# Finished with 0 retries | 1
# Finished with 1 retry   | 0
# TOTAL                   | 1
```

URL Stored in Indexd:
> s3://example-bucket/000d0430-e8dc-526b-a2f6-165ab7b9f2f2/example.txt 

Presigned URL Generated by Fence:  ⚠️
> https://example-bucket.s3.amazonaws.com/PREFIX/4804f485-c584-4c2a-962d-97440e9eb093/example.txt 

## Downloading File (404 error)  ⚠️

```sh
# Downloaded with 'Download Manifest' button in Explorer Page 
➜ cat file-manifest.json
[
  {
	"file_name": "example.txt",
	"md5sum": "e0c38194dbc33fd1af874f027e270c83",
	"object_id": "000d0430-e8dc-526b-a2f6-165ab7b9f2f2"
  }
]


➜  gen3-client download-multiple --profile=local --manifest=file-manifest.json
# 2024/06/07 19:28:47 Reading manifest...
#  150 B / 150 B [====================================================] 100.00% 0s
# WARNING: flag "rename" was set to false in "original" mode, duplicated files under "./" will be overwritten
# Proceed? [y/n]: y
# 2024/06/07 19:28:48 Total number of objects in manifest: 1
# 2024/06/07 19:28:48 Preparing file info for each file, please wait...
#  1 / 1 [============================================================] 100.00% 0s
# 2024/06/07 19:28:48 File info prepared successfully
# 2024/06/07 19:29:51 1 files have encountered an error during downloading, detailed error messages are:
# 2024/06/07 19:29:51 Got a non-200 or non-206 response when making request to URL associated with GUID bbcd8034-7109-5349-9c0f-d031ef32a9ec
# HTTP status code for response: 404 ⚠️
```

# New Behavior

## Uploading File  ✅

Running the same Command as above results in the Indexd URL and Presigned URL matching the expected path of the file:

URL Stored in Indexd:
> s3://<BUCKET>/000d0430-e8dc-526b-a2f6-165ab7b9f2f2/example.txt 

Presigned URL Generated by Fence:  ✅
> https://example-bucket.s3.amazonaws.com/000d0430-e8dc-526b-a2f6-165ab7b9f2f2/example.txt 

## Downloading File  ✅

```sh
# Downloaded with 'Download Manifest' button in Explorer Page 
➜ cat file-manifest.json
[
  {
	"file_name": "example.txt",
	"md5sum": "e0c38194dbc33fd1af874f027e270c83",
	"object_id": "000d0430-e8dc-526b-a2f6-165ab7b9f2f2"
  }
]

➜ gen3-client download-multiple --profile=local --manifest=file-manifest.json
# 2024/06/07 19:38:30 Reading manifest...
#  150 B / 150 B [====================================================] 100.00% 0s
# WARNING: flag "rename" was set to false in "original" mode, duplicated files under "./" will be overwritten
# Proceed? [y/n]: y
# 2024/06/07 19:38:31 Total number of objects in manifest: 1
# 2024/06/07 19:38:31 Preparing file info for each file, please wait...
#  1 / 1 [============================================================] 100.00% 0s
# 2024/06/07 19:38:31 File info prepared successfully
# date.26.txt  29 B / 29 B [=============================================] 100.00%
# 2024/06/07 19:38:31 1 files downloaded.  ✅

➜ cat example.txt
Example Data
```

# Notes

Let me know if this is either expected behavior or could be due to a misconfiguration on my end. Thanks for all your work on this! 🙌